### PR TITLE
feature: 소셜 로그인 기능 구현

### DIFF
--- a/src/main/java/com/anchor/AnchorApplication.java
+++ b/src/main/java/com/anchor/AnchorApplication.java
@@ -2,7 +2,9 @@ package com.anchor;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class AnchorApplication {
 

--- a/src/main/java/com/anchor/domain/mentor/domain/Mentor.java
+++ b/src/main/java/com/anchor/domain/mentor/domain/Mentor.java
@@ -32,6 +32,9 @@ public class Mentor extends BaseEntity {
   private String accountNumber;
 
   @Column(length = 20, nullable = false)
+  private String accountName;
+
+  @Column(length = 20, nullable = false)
   private String bankName;
 
   @OneToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/anchor/domain/user/domain/User.java
+++ b/src/main/java/com/anchor/domain/user/domain/User.java
@@ -14,6 +14,7 @@ import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -39,5 +40,17 @@ public class User extends BaseEntity {
 
   @OneToMany(mappedBy = "user")
   private List<MentoringApplication> mentoringApplicationList = new ArrayList<>();
+
+  @Builder
+  public User(String email, String nickname, String image, UserRole role) {
+    this.email = email;
+    this.nickname = nickname;
+    this.image = image;
+    this.role = role;
+  }
+
+  public String getRoleKey() {
+    return role.getKey();
+  }
 
 }

--- a/src/main/java/com/anchor/domain/user/domain/UserRole.java
+++ b/src/main/java/com/anchor/domain/user/domain/UserRole.java
@@ -7,10 +7,11 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum UserRole {
 
-  ADMIN("관리자"),
-  USER("회원"),
-  MENTOR("멘티");
+  ADMIN("ROLE_ADMIN", "관리자"),
+  USER("ROLE_USER", "회원"),
+  MENTOR("ROLE_MENTOR", "멘토");
 
-  private final String description;
+  public final String key;
+  public final String description;
 
 }

--- a/src/main/java/com/anchor/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/anchor/domain/user/domain/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.anchor.domain.user.domain.repository;
+
+import com.anchor.domain.user.domain.User;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+  Optional<User> findByEmail(String email);
+
+}

--- a/src/main/java/com/anchor/global/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/anchor/global/auth/CustomOAuth2UserService.java
@@ -1,0 +1,59 @@
+package com.anchor.global.auth;
+
+import com.anchor.domain.user.domain.User;
+import com.anchor.domain.user.domain.repository.UserRepository;
+import com.anchor.global.auth.OAuth2UserProviderRegistry.OAuth2LoginProviderType;
+import jakarta.servlet.http.HttpSession;
+import java.util.Collections;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+  private final UserRepository userRepository;
+  private final HttpSession httpSession;
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    OAuth2UserService<OAuth2UserRequest, OAuth2User> oauth2UserLoadProcessor = new DefaultOAuth2UserService();
+    OAuth2User oAuth2User = oauth2UserLoadProcessor.loadUser(userRequest);
+    String registrationId = userRequest.getClientRegistration()
+        .getRegistrationId();
+
+    OAuth2LoginProviderType providerType = OAuth2UserProviderRegistry.getType(registrationId);
+    String userNameAttributeName = userRequest.getClientRegistration()
+        .getProviderDetails()
+        .getUserInfoEndpoint()
+        .getUserNameAttributeName();
+    Map<String, Object> oAuth2UserResponse = oAuth2User.getAttributes();
+    OAuth2UserAttributes oAuth2UserAttributes = OAuth2UserAttributes.of(providerType,
+        userNameAttributeName, oAuth2UserResponse);
+
+    User user = save(oAuth2UserAttributes);
+    httpSession.setAttribute("user", new SessionUser(user));
+
+    return new DefaultOAuth2User(
+        Collections.singleton(new SimpleGrantedAuthority(user.getRoleKey())),
+        oAuth2UserAttributes.getAttributes(),
+        oAuth2UserAttributes.getNameAttributeKey()
+    );
+  }
+
+  private User save(OAuth2UserAttributes oAuth2UserAttributes) {
+    User user = userRepository.findByEmail(oAuth2UserAttributes.getEmail())
+        .orElse(oAuth2UserAttributes.toUserEntity());
+
+    return userRepository.save(user);
+  }
+
+}

--- a/src/main/java/com/anchor/global/auth/OAuth2UserAttributes.java
+++ b/src/main/java/com/anchor/global/auth/OAuth2UserAttributes.java
@@ -1,0 +1,64 @@
+package com.anchor.global.auth;
+
+import com.anchor.domain.user.domain.User;
+import com.anchor.domain.user.domain.UserRole;
+import com.anchor.global.auth.OAuth2UserProviderRegistry.OAuth2LoginProviderType;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class OAuth2UserAttributes {
+
+  private final Map<String, Object> attributes;
+  private final String nameAttributeKey;
+  private final String name;
+  private final String email;
+  private final String image;
+
+  @Builder
+  public OAuth2UserAttributes(
+      Map<String, Object> attributes, String nameAttributeKey, String name, String email,
+      String image
+  ) {
+    this.attributes = attributes;
+    this.nameAttributeKey = nameAttributeKey;
+    this.name = name;
+    this.email = email;
+    this.image = image;
+  }
+
+  @SuppressWarnings("unchecked")
+  public static OAuth2UserAttributes of(
+      OAuth2LoginProviderType providerType, String userNameAttributeName,
+      Map<String, Object> oAuth2UserResponse
+  ) {
+    Map<String, Object> attributes = oAuth2UserResponse;
+
+    if (providerType.hasAttributeField()) {
+      try {
+        attributes = (Map<String, Object>) oAuth2UserResponse.get(providerType.ATTRIBUTES_FIELD);
+      } catch (ClassCastException e) {
+        throw new IllegalArgumentException("주어진 속성 필드가 존재하지 않습니다.");
+      }
+    }
+
+    return OAuth2UserAttributes.builder()
+        .attributes(oAuth2UserResponse)
+        .name((String) attributes.get(providerType.NAME_FIELD))
+        .email((String) attributes.get(providerType.EMAIL_FIELD))
+        .image((String) attributes.get(providerType.IMAGE_FIELD))
+        .nameAttributeKey(userNameAttributeName)
+        .build();
+  }
+
+  public User toUserEntity() {
+    return User.builder()
+        .nickname(name)
+        .email(email)
+        .image(image)
+        .role(UserRole.USER)
+        .build();
+  }
+
+}

--- a/src/main/java/com/anchor/global/auth/OAuth2UserProviderRegistry.java
+++ b/src/main/java/com/anchor/global/auth/OAuth2UserProviderRegistry.java
@@ -1,0 +1,55 @@
+package com.anchor.global.auth;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+@Component
+public abstract class OAuth2UserProviderRegistry {
+
+  private static final Set<OAuth2LoginProviderType> oAuth2LoginProviderTypes = new HashSet<>();
+
+  static {
+    oAuth2LoginProviderTypes.add(OAuth2LoginProviderType.GOOGLE);
+    oAuth2LoginProviderTypes.add(OAuth2LoginProviderType.NAVER);
+  }
+
+  public static OAuth2LoginProviderType getType(String registrationId) {
+    return oAuth2LoginProviderTypes.stream()
+        .filter(oAuth2LoginProviderType ->
+            oAuth2LoginProviderType.isEqualTo(registrationId))
+        .findAny()
+        .orElseThrow(
+            () -> new IllegalArgumentException("주어진 registrationId와 일치하는 Provider가 없습니다."));
+  }
+
+  public enum OAuth2LoginProviderType {
+    GOOGLE("google", null, "name", "email", "picture"),
+    NAVER("naver", "response", "name", "email", "profile_image");
+
+    public final String REGISTRATION_ID;
+    public final String ATTRIBUTES_FIELD;
+    public final String NAME_FIELD;
+    public final String EMAIL_FIELD;
+    public final String IMAGE_FIELD;
+
+    OAuth2LoginProviderType(String REGISTRATION_ID, String ATTRIBUTES_FIELD, String NAME_FIELD,
+        String EMAIL_FIELD, String IMAGE_FIELD) {
+      this.REGISTRATION_ID = REGISTRATION_ID;
+      this.ATTRIBUTES_FIELD = ATTRIBUTES_FIELD;
+      this.NAME_FIELD = NAME_FIELD;
+      this.EMAIL_FIELD = EMAIL_FIELD;
+      this.IMAGE_FIELD = IMAGE_FIELD;
+    }
+
+    private boolean isEqualTo(String registrationId) {
+      return REGISTRATION_ID.equals(registrationId);
+    }
+
+    public boolean hasAttributeField() {
+      return ATTRIBUTES_FIELD != null;
+    }
+
+  }
+
+}

--- a/src/main/java/com/anchor/global/auth/SecurityConfig.java
+++ b/src/main/java/com/anchor/global/auth/SecurityConfig.java
@@ -1,0 +1,45 @@
+package com.anchor.global.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@RequiredArgsConstructor
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+  private final CustomOAuth2UserService customOAuth2UserService;
+
+  @Bean
+  public WebSecurityCustomizer webSecurityCustomizer() {
+    return web -> web.ignoring()
+        .requestMatchers(PathRequest.toStaticResources()
+            .atCommonLocations());
+  }
+
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    return http
+        .csrf(AbstractHttpConfigurer::disable)
+        .authorizeHttpRequests(requestMatcherRegistry -> requestMatcherRegistry
+            .requestMatchers("/auth")
+            .authenticated()
+            .anyRequest()
+            .permitAll())
+        .logout(logoutConfigurer -> logoutConfigurer
+            .logoutUrl("/logout")
+            .logoutSuccessUrl("/"))
+        .oauth2Login(oAuth2LoginConfigurer -> oAuth2LoginConfigurer
+            .userInfoEndpoint(userInfoEndpointConfig -> userInfoEndpointConfig
+                .userService(customOAuth2UserService)))
+        .build();
+  }
+
+}

--- a/src/main/java/com/anchor/global/auth/SessionUser.java
+++ b/src/main/java/com/anchor/global/auth/SessionUser.java
@@ -1,0 +1,22 @@
+package com.anchor.global.auth;
+
+import com.anchor.domain.user.domain.User;
+import java.io.Serializable;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SessionUser implements Serializable {
+
+  private String email;
+  private String nickname;
+  private String image;
+
+  public SessionUser(User user) {
+    this.email = user.getEmail();
+    this.nickname = user.getNickname();
+    this.image = user.getImage();
+  }
+
+}


### PR DESCRIPTION
# Abtract
- 스프링 시큐리티에서 지원하는 OIDC 기능을 이용해 소셜로그인을 구현하였습니다.
- Provider는 Google과 Naver입니다.

# Detail of Changes
## 1. 구글 로그인/회원가입 기능
- Path: /oauth2/authorization/google
- 위의 경로로 요청을 보내면 구글 로그인을 진행할 수 있습니다.

## 2. 네이버 로그인/회원가입 기능
- Path: /oauth2/authorization/naver
- 위의 경로로 요청을 보내면 구글 로그인을 진행할 수 있습니다.

## 3. 로그아웃
- Path: /logout
- 위의 경로로 요청을 보내면 로그아웃을 진행할 수 있습니다.

# To Others
- Redis를 이용한 분산 세션 및 DB에 데이터가 잘 들어오는 것을 확인했습니다.
- 권한 검증과 예외 처리는 다른 기능들이 구현된 이후에 추가하도록 하겠습니다.