### PR TITLE
feature: 멘토링 조회 기능 구현

### DIFF
--- a/src/main/java/com/anchor/domain/mentor/domain/Mentor.java
+++ b/src/main/java/com/anchor/domain/mentor/domain/Mentor.java
@@ -1,6 +1,7 @@
 package com.anchor.domain.mentor.domain;
 
 import com.anchor.domain.mentoring.domain.Mentoring;
+import com.anchor.domain.user.domain.User;
 import com.anchor.global.util.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -13,6 +14,7 @@ import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -44,4 +46,18 @@ public class Mentor extends BaseEntity {
   @OneToMany(mappedBy = "mentor")
   private List<Mentoring> mentoring = new ArrayList<>();
 
+  @OneToOne(mappedBy = "mentor")
+  private User user;
+
+  @Builder
+  private Mentor(String companyEmail, Career career, String accountNumber, String accountName,
+      String bankName, User user) {
+    this.companyEmail = companyEmail;
+    this.career = career;
+    this.accountNumber = accountNumber;
+    this.accountName = accountName;
+    this.bankName = bankName;
+    this.user = user;
+  }
+  
 }

--- a/src/main/java/com/anchor/domain/mentoring/api/controller/MentoringViewController.java
+++ b/src/main/java/com/anchor/domain/mentoring/api/controller/MentoringViewController.java
@@ -1,0 +1,39 @@
+package com.anchor.domain.mentoring.api.controller;
+
+import com.anchor.domain.mentoring.api.service.MentoringViewService;
+import com.anchor.domain.mentoring.api.service.response.MentoringDetailResponseDto;
+import com.anchor.domain.mentoring.api.service.response.MentoringResponseDto;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/mentorings")
+public class MentoringViewController {
+
+  private final MentoringViewService mentoringViewService;
+
+  @GetMapping("")
+  public ResponseEntity<List<MentoringResponseDto>> mentoringViewList() {
+
+    List<MentoringResponseDto> mentoringList = mentoringViewService.loadMentoringList();
+    return ResponseEntity.ok()
+        .body(mentoringList);
+  }
+
+  @GetMapping("/{id}")
+  public ResponseEntity<MentoringDetailResponseDto> viewMentoringDetail(
+      @PathVariable("id") Long id) {
+
+    MentoringDetailResponseDto mentoringDetail = mentoringViewService.loadMentoringDetail(id);
+
+    return ResponseEntity.ok()
+        .body(mentoringDetail);
+  }
+
+}

--- a/src/main/java/com/anchor/domain/mentoring/api/service/MentoringViewService.java
+++ b/src/main/java/com/anchor/domain/mentoring/api/service/MentoringViewService.java
@@ -1,0 +1,34 @@
+package com.anchor.domain.mentoring.api.service;
+
+import com.anchor.domain.mentoring.api.service.response.MentoringDetailResponseDto;
+import com.anchor.domain.mentoring.api.service.response.MentoringResponseDto;
+import com.anchor.domain.mentoring.domain.Mentoring;
+import com.anchor.domain.mentoring.domain.repository.MentoringRepository;
+import java.util.List;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class MentoringViewService {
+
+  private final MentoringRepository mentoringRepository;
+
+  @Transactional(readOnly = true)
+  public List<MentoringResponseDto> loadMentoringList() {
+    List<Mentoring> mentoringList = mentoringRepository.findAll();
+
+    return mentoringList.stream()
+        .map(MentoringResponseDto::new)
+        .toList();
+  }
+
+  @Transactional(readOnly = true)
+  public MentoringDetailResponseDto loadMentoringDetail(Long id) throws NoSuchElementException {
+    Mentoring findMentoring = mentoringRepository.findById(id)
+        .orElseThrow(() -> new NoSuchElementException(id + "에 해당하는 멘토링이 존재하지 않습니다."));
+    return new MentoringDetailResponseDto(findMentoring);
+  }
+}

--- a/src/main/java/com/anchor/domain/mentoring/api/service/response/MentoringDetailResponseDto.java
+++ b/src/main/java/com/anchor/domain/mentoring/api/service/response/MentoringDetailResponseDto.java
@@ -1,0 +1,31 @@
+package com.anchor.domain.mentoring.api.service.response;
+
+import com.anchor.domain.mentoring.domain.Mentoring;
+import com.anchor.domain.mentoring.domain.MentoringTag;
+import java.util.List;
+
+public record MentoringDetailResponseDto(
+    String title,
+    String durationTime,
+    String content,
+    String nickname,
+    Integer cost,
+    List<String> tags
+) {
+
+  public MentoringDetailResponseDto(Mentoring mentoring) {
+    this(mentoring.getTitle(),
+        mentoring.getDurationTime(),
+        mentoring.getMentoringDetail()
+            .getContents(),
+        mentoring.getMentor()
+            .getUser()
+            .getNickname(),
+        mentoring.getCost(),
+        mentoring.getMentoringTag()
+            .stream()
+            .map(MentoringTag::getTag)
+            .toList());
+
+  }
+}

--- a/src/main/java/com/anchor/domain/mentoring/api/service/response/MentoringResponseDto.java
+++ b/src/main/java/com/anchor/domain/mentoring/api/service/response/MentoringResponseDto.java
@@ -1,0 +1,16 @@
+package com.anchor.domain.mentoring.api.service.response;
+
+import com.anchor.domain.mentoring.domain.Mentoring;
+
+public record MentoringResponseDto(String title, String nickname, String durationTime,
+                                   Integer cost) {
+
+  public MentoringResponseDto(Mentoring mentoring) {
+    this(mentoring.getTitle(),
+        mentoring.getMentor()
+            .getUser()
+            .getNickname(),
+        mentoring.getDurationTime(),
+        mentoring.getCost());
+  }
+}

--- a/src/main/java/com/anchor/domain/mentoring/domain/Mentoring.java
+++ b/src/main/java/com/anchor/domain/mentoring/domain/Mentoring.java
@@ -12,11 +12,14 @@ import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@DynamicInsert
 @Entity
 public class Mentoring extends BaseEntity {
 
@@ -29,7 +32,7 @@ public class Mentoring extends BaseEntity {
   @Column(nullable = false)
   private Integer cost;
 
-  @Column(nullable = false, columnDefinition = "int default 0")
+  @Column(columnDefinition = "int default 0")
   private Integer totalApplicationNumber;
 
   @ManyToOne(fetch = FetchType.LAZY)
@@ -50,4 +53,13 @@ public class Mentoring extends BaseEntity {
   @OneToMany(mappedBy = "mentoring")
   private List<MentoringApplication> mentoringApplications = new ArrayList<>();
 
+  @Builder
+  private Mentoring(String title, String durationTime, Integer cost, Mentor mentor,
+      MentoringDetail mentoringDetail) {
+    this.title = title;
+    this.durationTime = durationTime;
+    this.cost = cost;
+    this.mentor = mentor;
+    this.mentoringDetail = mentoringDetail;
+  }
 }

--- a/src/main/java/com/anchor/domain/mentoring/domain/MentoringDetail.java
+++ b/src/main/java/com/anchor/domain/mentoring/domain/MentoringDetail.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Lob;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,4 +18,8 @@ public class MentoringDetail extends BaseEntity {
   @Column(nullable = false)
   private String contents;
 
+  @Builder
+  private MentoringDetail(String contents) {
+    this.contents = contents;
+  }
 }

--- a/src/main/java/com/anchor/domain/mentoring/domain/MentoringTag.java
+++ b/src/main/java/com/anchor/domain/mentoring/domain/MentoringTag.java
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,4 +23,15 @@ public class MentoringTag extends BaseEntity {
   @JoinColumn(name = "mentoring_id")
   private Mentoring mentoring;
 
+  @Builder
+  private MentoringTag(String tag, Mentoring mentoring) {
+    this.tag = tag;
+    setMentoring(mentoring);
+  }
+
+  private void setMentoring(Mentoring mentoring) {
+    this.mentoring = mentoring;
+    mentoring.getMentoringTag()
+        .add(this);
+  }
 }

--- a/src/main/java/com/anchor/domain/mentoring/domain/repository/MentoringRepository.java
+++ b/src/main/java/com/anchor/domain/mentoring/domain/repository/MentoringRepository.java
@@ -1,0 +1,9 @@
+package com.anchor.domain.mentoring.domain.repository;
+
+
+import com.anchor.domain.mentoring.domain.Mentoring;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
+
+}

--- a/src/test/java/com/anchor/domain/mentoring/api/service/MentoringViewServiceTest.java
+++ b/src/test/java/com/anchor/domain/mentoring/api/service/MentoringViewServiceTest.java
@@ -1,0 +1,147 @@
+package com.anchor.domain.mentoring.api.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.tuple;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.anchor.domain.mentor.domain.Career;
+import com.anchor.domain.mentor.domain.Mentor;
+import com.anchor.domain.mentoring.api.service.response.MentoringDetailResponseDto;
+import com.anchor.domain.mentoring.api.service.response.MentoringResponseDto;
+import com.anchor.domain.mentoring.domain.Mentoring;
+import com.anchor.domain.mentoring.domain.MentoringDetail;
+import com.anchor.domain.mentoring.domain.MentoringTag;
+import com.anchor.domain.mentoring.domain.repository.MentoringRepository;
+import com.anchor.domain.user.domain.User;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MentoringViewServiceTest {
+
+  @Mock
+  private MentoringRepository mentoringRepository;
+
+  @InjectMocks
+  private MentoringViewService mentoringViewService;
+  private User testUser;
+  private Mentor testMentor;
+
+  @BeforeEach
+  void testUserAndMentorInit() {
+    testUser = User.builder()
+        .email("testUser@test.com")
+        .nickname("테스트유저")
+        .build();
+    testMentor = Mentor.builder()
+        .companyEmail("testCompany@test.com")
+        .accountName("계좌명")
+        .accountNumber("12345678")
+        .bankName("테스트은행")
+        .career(Career.MIDDLE)
+        .user(testUser)
+        .build();
+  }
+
+  @Test
+  @DisplayName("전체 멘토링 목록을 조회한다.")
+  void loadMentoringListTest() {
+    //given
+    List<Mentoring> mentoringList = new ArrayList<>();
+
+    for (int i = 1; i <= 5; i++) {
+      Mentoring testMentoring = Mentoring.builder()
+          .title("테스트타이틀" + i)
+          .durationTime("1시간")
+          .cost(10_000)
+          .mentor(testMentor)
+          .build();
+      mentoringList.add(testMentoring);
+    }
+
+    //when
+    when(mentoringRepository.findAll()).thenReturn(mentoringList);
+    List<MentoringResponseDto> result = mentoringViewService.loadMentoringList();
+
+    //then
+    assertThat(result).hasSize(mentoringList.size())
+        .extracting("title", "durationTime", "cost", "nickname")
+        .containsExactlyInAnyOrder(
+            tuple("테스트타이틀1", "1시간", 10_000, testUser.getNickname()),
+            tuple("테스트타이틀2", "1시간", 10_000, testUser.getNickname()),
+            tuple("테스트타이틀3", "1시간", 10_000, testUser.getNickname()),
+            tuple("테스트타이틀4", "1시간", 10_000, testUser.getNickname()),
+            tuple("테스트타이틀5", "1시간", 10_000, testUser.getNickname())
+        );
+  }
+
+  @Test
+  @DisplayName("멘토링 ID를 입력받으면 멘토링 상세정보를 출력한다.")
+  void loadMentoringDetailTest() {
+    //given
+    Long id = 1L;
+
+    MentoringDetail testDetail = MentoringDetail.builder()
+        .contents("테스트내용")
+        .build();
+    Mentoring testMentoring = Mentoring.builder()
+        .title("테스트타이틀")
+        .durationTime("1시간")
+        .cost(10_000)
+        .mentor(testMentor)
+        .mentoringDetail(testDetail)
+        .build();
+    List<MentoringTag> testTags = new ArrayList<>();
+    fillTags(testTags, testMentoring);
+    when(mentoringRepository.findById(anyLong())).thenReturn(Optional.of(testMentoring));
+
+    //when
+    MentoringDetailResponseDto result = mentoringViewService.loadMentoringDetail(id);
+
+    //then
+    assertThat(result).extracting("title", "content", "durationTime", "nickname", "cost")
+        .contains("테스트타이틀", "테스트내용", "1시간", "테스트유저", 10_000);
+    assertThat(result.tags()).hasSize(2)
+        .contains("자바", "백엔드");
+  }
+
+  @Test
+  @DisplayName("존재하지 않는 멘토링 ID를 입력하면 예외를 발생시킨다.")
+  void loadMentoringDetailFailureTest() {
+    //given
+    Long id = 999L;
+    String exceptionMessage = "잘못된 출력입니다.";
+    when(mentoringRepository.findById(anyLong())).thenThrow(
+        new NoSuchElementException(exceptionMessage));
+
+    //when then
+    assertThatThrownBy(() -> mentoringViewService.loadMentoringDetail(id)).isInstanceOf(
+            NoSuchElementException.class)
+        .hasMessage(exceptionMessage);
+    
+  }
+
+  private void fillTags(List<MentoringTag> testTags, Mentoring mentoring) {
+    MentoringTag backEndTag = MentoringTag.builder()
+        .tag("백엔드")
+        .mentoring(mentoring)
+        .build();
+    MentoringTag javaTag = MentoringTag.builder()
+        .tag("자바")
+        .mentoring(mentoring)
+        .build();
+    testTags.add(backEndTag);
+    testTags.add(javaTag);
+  }
+}


### PR DESCRIPTION
# Abtract
- 게시된 멘토링 목록 조회와 멘토링 상세정보 조회 기능을 구현하였습니다.

# Detail of Changes
## 1. 멘토링 목록 조회
- Path: /mentorings `GET`
- 위 경로로 요청을 보내면 게시되어있는 멘토링 목록을 조회합니다.
## 2. 멘토링 상세정보 조회
- Path: /mentorings/{id} `GET`
- 위 경로로 요청을 보내면 {id} 값을 사용해 멘토링 상세정보를 조회합니다.
- {id} 멘토링 데이터가 없을시, NoSuchElementException을 발생시킵니다.
# To Others
- record 클래스를 사용해 Dto객체를 구현하였습니다.
- 예외처리는 다른 기능 구현 후 추가하겠습니다.