### PR TITLE
feature: 회원 정보 기능 구현 

### DIFF
--- a/src/main/java/com/anchor/domain/user/api/controller/UserController.java
+++ b/src/main/java/com/anchor/domain/user/api/controller/UserController.java
@@ -20,7 +20,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RequiredArgsConstructor
 @RequestMapping
 @RestController("/users")

--- a/src/main/java/com/anchor/domain/user/api/controller/UserController.java
+++ b/src/main/java/com/anchor/domain/user/api/controller/UserController.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 
@@ -22,6 +23,30 @@ public class UserController {
   private static final String SUCCESS = "success";
   private static final String FAILURE = "failure";
   private final UserService userService;
+
+  /**
+   *  유저 정보 변경
+   */
+  @PutMapping("/me")
+  public ResponseEntity<String> putInfo(@RequestBody UserNicknameRequest userNicknameRequest, HttpSession httpSession){
+    SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
+    userService.editNickname(sessionUser.getEmail(), userNicknameRequest);
+    return ResponseEntity.ok().build();
+  }
+
+  @PutMapping("/me/image")
+  public ResponseEntity<String> putImage(@RequestBody UserNicknameRequest userNicknameRequest, HttpSession httpSession){
+    return ResponseEntity.ok().build();
+  }
+
+  @DeleteMapping
+  public ResponseEntity<String> deleteUser(HttpSession httpSession){
+    SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user"); //email, nickname, image
+    userService.deleteUser(sessionUser.getEmail());
+    return ResponseEntity.ok().build();
+  }
+
+
 
   /**
    * 멘토링 신청내역을 조회합니다.
@@ -60,4 +85,6 @@ public class UserController {
     }
     return sessionUser;
   }
+
+
 }

--- a/src/main/java/com/anchor/domain/user/api/controller/UserController.java
+++ b/src/main/java/com/anchor/domain/user/api/controller/UserController.java
@@ -1,23 +1,29 @@
 package com.anchor.domain.user.api.controller;
 
 import com.anchor.domain.user.api.controller.request.MentoringStatusInfo;
+import com.anchor.domain.user.api.controller.request.UserNicknameRequest;
 import com.anchor.domain.user.api.service.UserService;
 import com.anchor.domain.user.api.service.response.AppliedMentoringInfo;
+import com.anchor.domain.user.api.service.response.UserInfoResponse;
 import com.anchor.global.auth.SessionUser;
 import jakarta.servlet.http.HttpSession;
 import java.util.List;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+
 @RequiredArgsConstructor
-@RequestMapping("/users")
+@RequestMapping
+@RestController("/users")
 public class UserController {
 
   private static final String SUCCESS = "success";
@@ -39,13 +45,12 @@ public class UserController {
     return ResponseEntity.ok().build();
   }
 
-  @DeleteMapping
+  @DeleteMapping("/me")
   public ResponseEntity<String> deleteUser(HttpSession httpSession){
     SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user"); //email, nickname, image
     userService.deleteUser(sessionUser.getEmail());
     return ResponseEntity.ok().build();
   }
-
 
 
   /**

--- a/src/main/java/com/anchor/domain/user/api/controller/UserViewController.java
+++ b/src/main/java/com/anchor/domain/user/api/controller/UserViewController.java
@@ -1,0 +1,29 @@
+package com.anchor.domain.user.api.controller;
+
+import com.anchor.domain.user.api.service.UserService;
+import com.anchor.domain.user.api.service.response.UserInfoResponse;
+import com.anchor.global.auth.SessionUser;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequiredArgsConstructor
+@RequestMapping("/users")
+@Controller
+public class UserViewController {
+
+  private final UserService userService;
+
+  @GetMapping("/me")
+  public String getInfo(Model model, HttpSession httpSession){
+    SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user"); //email, nickname, image
+    String email = sessionUser.getEmail();
+    UserInfoResponse userInfoResponse = userService.getProfile(email);
+    model.addAttribute("user", userInfoResponse);
+    return "내 프로필 페이지 조회";
+  }
+
+}

--- a/src/main/java/com/anchor/domain/user/api/controller/request/UserNicknameRequest.java
+++ b/src/main/java/com/anchor/domain/user/api/controller/request/UserNicknameRequest.java
@@ -1,0 +1,17 @@
+package com.anchor.domain.user.api.controller.request;
+
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserNicknameRequest {
+
+  private String nickname;
+
+  public UserNicknameRequest(String nickname) {
+    this.nickname = nickname;
+  }
+
+}

--- a/src/main/java/com/anchor/domain/user/api/service/UserService.java
+++ b/src/main/java/com/anchor/domain/user/api/service/UserService.java
@@ -41,7 +41,7 @@ public class UserService {
   }
 
   @Transactional
-  public void modifyNickname(String email, UserNicknameRequest userNicknameRequest){
+  public void editNickname(String email, UserNicknameRequest userNicknameRequest){
     User user = userRepository.findByEmail(email)
         .orElseThrow(()->{
           return new RuntimeException("해당 유저를 찾을 수 없습니다.");

--- a/src/main/java/com/anchor/domain/user/api/service/UserService.java
+++ b/src/main/java/com/anchor/domain/user/api/service/UserService.java
@@ -47,6 +47,7 @@ public class UserService {
           return new RuntimeException("해당 유저를 찾을 수 없습니다.");
         });
     user.editNickname(userNicknameRequest);
+    userRepository.save(user);
   }
 
   @Transactional

--- a/src/main/java/com/anchor/domain/user/api/service/UserService.java
+++ b/src/main/java/com/anchor/domain/user/api/service/UserService.java
@@ -31,6 +31,33 @@ public class UserService {
   private final PaymentRepository paymentRepository;
   private final ExternalApiUtil apiUtil;
 
+  @Transactional
+  public UserInfoResponse getProfile(String email){
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(()->{
+          return new RuntimeException("해당 유저를 찾을 수 없습니다.");
+        });
+    return new UserInfoResponse(user);
+  }
+
+  @Transactional
+  public void modifyNickname(String email, UserNicknameRequest userNicknameRequest){
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(()->{
+          return new RuntimeException("해당 유저를 찾을 수 없습니다.");
+        });
+    user.editNickname(userNicknameRequest);
+  }
+
+  @Transactional
+  public void deleteUser(String email){
+    User user = userRepository.findByEmail(email)
+        .orElseThrow(()->{
+          return new RuntimeException("해당 유저를 찾을 수 없습니다.");
+        });
+    userRepository.delete(user);
+  }
+
   @Transactional(readOnly = true)
   public List<AppliedMentoringInfo> loadAppliedMentoringList(SessionUser sessionUser) {
 

--- a/src/main/java/com/anchor/domain/user/api/service/response/UserInfoResponse.java
+++ b/src/main/java/com/anchor/domain/user/api/service/response/UserInfoResponse.java
@@ -1,0 +1,40 @@
+package com.anchor.domain.user.api.service.response;
+
+import com.anchor.domain.mentor.domain.Mentor;
+import com.anchor.domain.mentoring.domain.MentoringApplication;
+import com.anchor.domain.user.domain.User;
+import com.anchor.domain.user.domain.UserRole;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UserInfoResponse {
+
+  private String email;
+  private String nickname;
+  private String image;
+  private UserRole role;
+  private Mentor mentor;
+  private List<MentoringApplication> mentoringApplicationList = new ArrayList<>();
+
+  public UserInfoResponse(User user){
+    this.email = user.getEmail();
+    this.nickname = user.getNickname();
+    this.image = user.getImage();
+    this.role = user.getRole();
+    this.mentor = user.getMentor();
+    this.mentoringApplicationList = user.getMentoringApplicationList();
+  }
+
+}

--- a/src/main/java/com/anchor/domain/user/domain/User.java
+++ b/src/main/java/com/anchor/domain/user/domain/User.java
@@ -2,6 +2,7 @@ package com.anchor.domain.user.domain;
 
 import com.anchor.domain.mentor.domain.Mentor;
 import com.anchor.domain.mentoring.domain.MentoringApplication;
+import com.anchor.domain.user.api.controller.request.UserNicknameRequest;
 import com.anchor.global.util.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -49,6 +50,10 @@ public class User extends BaseEntity {
 
   public String getRoleKey() {
     return role.getKey();
+  }
+
+  public void editNickname(UserNicknameRequest userNicknameRequest){
+    this.nickname = userNicknameRequest.getNickname();
   }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,8 +3,9 @@ spring:
   profiles:
     active: local
     include:
+      - oauth
+      - session
       - aws
-      - pay
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
@@ -87,4 +88,3 @@ rest-template:
 #  h2:
 #    console:
 #      enabled: true
-

--- a/src/test/java/com/anchor/domain/user/api/service/UserServiceTest.java
+++ b/src/test/java/com/anchor/domain/user/api/service/UserServiceTest.java
@@ -59,14 +59,125 @@ class UserServiceTest {
 
   @Mock
   PaymentRepository paymentRepository;
+
   @Mock
   ExternalApiUtil apiUtil;
 
   @InjectMocks
   UserService userService;
 
+
+
+
+
   private User user;
   private SessionUser sessionUser;
+
+  private UserInfoResponse userInfoResponse(User user){
+    return new UserInfoResponse(user);
+  }
+
+
+  @DisplayName("회원 정보 조회 - 성공")
+  @Test
+  void getProfile() {
+    //given
+    String userEmail = "mark@smtown";
+    User user = User.builder()
+        .email(userEmail)
+        .nickname("mark")
+        .role(UserRole.USER)
+        .build();
+    userRepository.save(user);
+    when(userRepository.findByEmail(userEmail)).thenReturn(Optional.of(user));
+
+    // when
+    UserInfoResponse userInfoResponse = userService.getProfile(userEmail);
+
+    // then
+    assertNotNull(userInfoResponse);
+    assertEquals("mark", userInfoResponse.getNickname());
+    assertEquals(userEmail, userInfoResponse.getEmail());
+    assertEquals(UserRole.USER, userInfoResponse.getRole());
+
+  }
+
+  @DisplayName("회원 정보 조회 - 실패 (유저를 찾을 수 없음)")
+  @Test
+  void getProfile_Fail_UserNotFound() {
+    // given
+    String userEmail = "nonexistent@smtown";
+    when(userRepository.findByEmail(userEmail)).thenReturn(Optional.empty());
+
+    // when, then
+    assertThrows(RuntimeException.class, () -> userService.getProfile(userEmail));
+  }
+
+
+  @DisplayName("닉네임 수정 - 성공")
+  @Test
+  void editNickname_Success() {
+    // given
+    String userEmail = "mark@smtown";
+    User user = User.builder()
+        .email(userEmail)
+        .nickname("mark")
+        .role(UserRole.USER)
+        .build();
+    when(userRepository.findByEmail(userEmail)).thenReturn(Optional.of(user));
+    UserNicknameRequest userNicknameRequest = new UserNicknameRequest("newMark");
+
+    // when
+    assertDoesNotThrow(() -> userService.editNickname(userEmail, userNicknameRequest));
+
+    // then
+    assertEquals("newMark", user.getNickname());
+  }
+
+  @DisplayName("닉네임 수정 - 실패 (유저를 찾을 수 없음)")
+  @Test
+  void editNickname_Fail_UserNotFound() {
+    // given
+    String userEmail = "nonexistent@smtown";
+    UserNicknameRequest userNicknameRequest = new UserNicknameRequest("newMark");
+    when(userRepository.findByEmail(userEmail)).thenReturn(Optional.empty());
+
+    // when, then
+    assertThrows(RuntimeException.class, () -> userService.editNickname(userEmail, userNicknameRequest));
+  }
+
+
+
+  @DisplayName("유저 삭제 - 성공")
+  @Test
+  void deleteUser_Success() {
+    // given
+    String userEmail = "mark@smtown";
+    User user = User.builder()
+        .email(userEmail)
+        .nickname("mark")
+        .role(UserRole.USER)
+        .build();
+    when(userRepository.findByEmail(userEmail)).thenReturn(Optional.of(user));
+
+    // when
+    assertDoesNotThrow(() -> userService.deleteUser(userEmail));
+
+    // then
+    verify(userRepository, times(1)).delete(user);
+  }
+
+  @DisplayName("유저 삭제 - 실패 (유저를 찾을 수 없음)")
+  @Test
+  void deleteUser_Fail_UserNotFound() {
+    // given
+    String userEmail = "nonexistent@smtown";
+    when(userRepository.findByEmail(userEmail)).thenReturn(Optional.empty());
+
+    // when, then
+    assertThrows(RuntimeException.class, () -> userService.deleteUser(userEmail));
+    verify(userRepository, never()).delete(any());
+  }
 
   @BeforeEach
   void initUserAndSessionUser() {
@@ -460,5 +571,129 @@ class UserServiceTest {
       );
     }
     return statusList;
+=======
+  @InjectMocks
+  private UserService userService;
+
+  @Mock
+  private UserRepository userRepository;
+
+
+  @BeforeAll
+  static void beforeAll(){
+    System.out.println("Start Test");
+  }
+
+  @AfterAll
+  static void afterAll(){
+    System.out.println("End Test");
+  }
+
+
+  private UserInfoResponse userInfoResponse(User user){
+    return new UserInfoResponse(user);
+  }
+
+
+  @DisplayName("회원 정보 조회 - 성공")
+  @Test
+  void getProfile() {
+    //given
+    String userEmail = "mark@smtown";
+    User user = User.builder()
+        .email(userEmail)
+        .nickname("mark")
+        .role(UserRole.USER)
+        .build();
+    userRepository.save(user);
+    when(userRepository.findByEmail(userEmail)).thenReturn(Optional.of(user));
+
+    // when
+    UserInfoResponse userInfoResponse = userService.getProfile(userEmail);
+
+    // then
+    assertNotNull(userInfoResponse);
+    assertEquals("mark", userInfoResponse.getNickname());
+    assertEquals(userEmail, userInfoResponse.getEmail());
+    assertEquals(UserRole.USER, userInfoResponse.getRole());
+
+  }
+
+  @DisplayName("회원 정보 조회 - 실패 (유저를 찾을 수 없음)")
+  @Test
+  void getProfile_Fail_UserNotFound() {
+    // given
+    String userEmail = "nonexistent@smtown";
+    when(userRepository.findByEmail(userEmail)).thenReturn(Optional.empty());
+
+    // when, then
+    assertThrows(RuntimeException.class, () -> userService.getProfile(userEmail));
+  }
+
+
+  @DisplayName("닉네임 수정 - 성공")
+  @Test
+  void editNickname_Success() {
+    // given
+    String userEmail = "mark@smtown";
+    User user = User.builder()
+        .email(userEmail)
+        .nickname("mark")
+        .role(UserRole.USER)
+        .build();
+    when(userRepository.findByEmail(userEmail)).thenReturn(Optional.of(user));
+    UserNicknameRequest userNicknameRequest = new UserNicknameRequest("newMark");
+
+    // when
+    assertDoesNotThrow(() -> userService.editNickname(userEmail, userNicknameRequest));
+
+    // then
+    assertEquals("newMark", user.getNickname());
+  }
+
+  @DisplayName("닉네임 수정 - 실패 (유저를 찾을 수 없음)")
+  @Test
+  void editNickname_Fail_UserNotFound() {
+    // given
+    String userEmail = "nonexistent@smtown";
+    UserNicknameRequest userNicknameRequest = new UserNicknameRequest("newMark");
+    when(userRepository.findByEmail(userEmail)).thenReturn(Optional.empty());
+
+    // when, then
+    assertThrows(RuntimeException.class, () -> userService.editNickname(userEmail, userNicknameRequest));
+  }
+
+
+
+  @DisplayName("유저 삭제 - 성공")
+  @Test
+  void deleteUser_Success() {
+    // given
+    String userEmail = "mark@smtown";
+    User user = User.builder()
+        .email(userEmail)
+        .nickname("mark")
+        .role(UserRole.USER)
+        .build();
+    when(userRepository.findByEmail(userEmail)).thenReturn(Optional.of(user));
+
+    // when
+    assertDoesNotThrow(() -> userService.deleteUser(userEmail));
+
+    // then
+    verify(userRepository, times(1)).delete(user);
+  }
+
+  @DisplayName("유저 삭제 - 실패 (유저를 찾을 수 없음)")
+  @Test
+  void deleteUser_Fail_UserNotFound() {
+    // given
+    String userEmail = "nonexistent@smtown";
+    when(userRepository.findByEmail(userEmail)).thenReturn(Optional.empty());
+
+    // when, then
+    assertThrows(RuntimeException.class, () -> userService.deleteUser(userEmail));
+    verify(userRepository, never()).delete(any());
+>>>>>>> 15a509f (git commit -m ")
   }
 }


### PR DESCRIPTION
# Abtract
- 회원 정보 : 로그인 후 개인정보를 확인하고 수정(닉네임, 프로필 사진)할 수 있습니다.

# Detail of Changes
## 1. 나의 회원 정보 페이지 조회
- Path: [get] /users/me
- 위 경로로 요청을 보내면 SessionUser의 email을 사용해 회원 정보 페이지로 이동합니다.
- 유저 데이터가 없을 시,  RuntimeException을 발생시킵니다.
## 2. 나의 회원 정보 수정
- Path: [put] /users/me
- 위 경로로 요청을 보내면 SessionUser의 email을 사용해 회원 닉네임을 수정할 수 있습니다.
- 유저 데이터가 없을 시,  RuntimeException을 발생시킵니다.
## 3-1. S3이미지 업로드기능 구현
- Path: [post] /image/upload 
- 위 경로로 요청을 보내면 s3 저장소에 이미지가 저장되고 imageUrl을 응답해줍니다
## 3-2. 나의 회원 이미지 수정 
- Path: [put] /users/me/image
- 위 경로로 요청을 보내면 SessionUser의 email을 사용해 회원 이미지를 수정할 수 있습니다.
- 이미지는 aws S3에 저장됩니다. 
- 유저 데이터가 없을 시,  RuntimeException을 발생시킵니다.
## 4. 회원 탈퇴
- Path: [delete] /users/me
- 위 경로로 요청을 보내면 SessionUser의 email을 사용해 회원 탈퇴가 가능합니다.
- 유저 데이터가 없을 시,  RuntimeException을 발생시킵니다.



# To Others
- [3-2. 나의 회원 이미지 수정] 부분은 진행중입니다.