### PR TITLE
feature: 멘토링 검색 기능 구현

### DIFF
--- a/src/main/java/com/anchor/domain/mentor/api/controller/MentorController.java
+++ b/src/main/java/com/anchor/domain/mentor/api/controller/MentorController.java
@@ -34,8 +34,7 @@ public class MentorController {
                         .build());
     return ResponseEntity.ok(result);
   }
-
-
+  
   @PostMapping("/schedule")
   public ResponseEntity<String> registerUnavailableTimes(
       @Valid @RequestBody MentoringUnavailableTimeInfo mentoringUnavailableTimeInfo, HttpSession httpSession) {

--- a/src/main/java/com/anchor/domain/mentor/domain/Mentor.java
+++ b/src/main/java/com/anchor/domain/mentor/domain/Mentor.java
@@ -3,59 +3,66 @@ package com.anchor.domain.mentor.domain;
 import com.anchor.domain.mentoring.domain.Mentoring;
 import com.anchor.domain.user.domain.User;
 import com.anchor.global.util.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Mentor extends BaseEntity {
 
-    @Column(length = 50, unique = true)
-    private String companyEmail;
+  @Column(length = 50, unique = true)
+  private String companyEmail;
 
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
-    private Career career;
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Career career;
 
-    @Column(length = 40, nullable = false)
-    private String accountNumber;
+  @Column(length = 40, nullable = false)
+  private String accountNumber;
 
-    @Column(length = 20, nullable = false)
-    private String accountName;
+  @Column(length = 20, nullable = false)
+  private String accountName;
 
-    @Column(length = 20, nullable = false)
-    private String bankName;
+  @Column(length = 20, nullable = false)
+  private String bankName;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "mentor_introduction_id")
-    private MentorIntroduction mentorIntroduction;
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "mentor_introduction_id")
+  private MentorIntroduction mentorIntroduction;
 
-    @OneToMany(
-            mappedBy = "mentor",
-            cascade = CascadeType.ALL
-    )
-    private List<Mentoring> mentorings = new ArrayList<>();
+  @OneToMany(
+      mappedBy = "mentor",
+      cascade = CascadeType.ALL
+  )
+  private List<Mentoring> mentorings = new ArrayList<>();
 
-    @OneToOne(mappedBy = "mentor")
-    private User user;
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "user_id")
+  private User user;
 
-    @Builder
-    private Mentor(Long id, String companyEmail, Career career, String accountNumber, String accountName,
-                   String bankName, User user) {
-        super(id);
-        this.companyEmail = companyEmail;
-        this.career = career;
-        this.accountNumber = accountNumber;
-        this.accountName = accountName;
-        this.bankName = bankName;
-        this.user = user;
-    }
+  @Builder
+  private Mentor(String companyEmail, Career career, String accountNumber, String accountName, String bankName,
+      User user) {
+    this.companyEmail = companyEmail;
+    this.career = career;
+    this.accountNumber = accountNumber;
+    this.accountName = accountName;
+    this.bankName = bankName;
+    this.user = user;
+  }
 
 }

--- a/src/main/java/com/anchor/domain/mentoring/api/controller/MentoringViewController.java
+++ b/src/main/java/com/anchor/domain/mentoring/api/controller/MentoringViewController.java
@@ -2,12 +2,19 @@ package com.anchor.domain.mentoring.api.controller;
 
 import com.anchor.domain.mentoring.api.service.MentoringService;
 import com.anchor.domain.mentoring.api.service.response.MentoringContents;
+import com.anchor.domain.mentoring.api.service.response.MentoringSearchResult;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @RequiredArgsConstructor
 @RequestMapping("/mentorings")
@@ -15,6 +22,22 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class MentoringViewController {
 
   private final MentoringService mentoringService;
+  private final boolean aBoolean = false;
+
+  @GetMapping
+  public String viewMentoringPage(
+      @RequestParam(value = "tag", required = aBoolean) List<String> tags,
+      @RequestParam(value = "keyword", required = false) String keyword,
+      @PageableDefault(size = 16,
+          sort = {"id", "totalApplicationNumber"}, direction = Sort.Direction.DESC) Pageable pageable,
+      Model model
+  ) {
+    Page<MentoringSearchResult> result = mentoringService.getMentorings(tags, keyword, pageable);
+    model.addAttribute("mentorings", result);
+
+    return "mentoring-edit";
+  }
+
 
   @GetMapping("/new")
   public String viewMentoringCreationPage() {

--- a/src/main/java/com/anchor/domain/mentoring/api/controller/request/MentoringContentsInfo.java
+++ b/src/main/java/com/anchor/domain/mentoring/api/controller/request/MentoringContentsInfo.java
@@ -2,6 +2,7 @@ package com.anchor.domain.mentoring.api.controller.request;
 
 import jakarta.validation.constraints.NotBlank;
 import java.util.List;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -14,6 +15,7 @@ public class MentoringContentsInfo {
 
   private List<String> tags;
 
+  @Builder
   public MentoringContentsInfo(String contents, List<String> tags) {
     this.tags = tags;
     this.contents = contents;

--- a/src/main/java/com/anchor/domain/mentoring/api/service/MentoringService.java
+++ b/src/main/java/com/anchor/domain/mentoring/api/service/MentoringService.java
@@ -6,11 +6,23 @@ import com.anchor.domain.mentoring.api.controller.request.MentoringApplicationIn
 import com.anchor.domain.mentoring.api.controller.request.MentoringApplicationTime;
 import com.anchor.domain.mentoring.api.controller.request.MentoringBasicInfo;
 import com.anchor.domain.mentoring.api.controller.request.MentoringContentsInfo;
-import com.anchor.domain.mentoring.api.service.response.*;
+import com.anchor.domain.mentoring.api.service.response.ApplicationUnavailableTime;
+import com.anchor.domain.mentoring.api.service.response.MentoringContents;
+import com.anchor.domain.mentoring.api.service.response.MentoringContentsEditResult;
+import com.anchor.domain.mentoring.api.service.response.MentoringCreateResult;
+import com.anchor.domain.mentoring.api.service.response.MentoringDefaultInfo;
+import com.anchor.domain.mentoring.api.service.response.MentoringDeleteResult;
+import com.anchor.domain.mentoring.api.service.response.MentoringDetailInfo;
+import com.anchor.domain.mentoring.api.service.response.MentoringEditResult;
+import com.anchor.domain.mentoring.api.service.response.MentoringPaymentInfo;
+import com.anchor.domain.mentoring.api.service.response.MentoringSearchResult;
 import com.anchor.domain.mentoring.domain.Mentoring;
 import com.anchor.domain.mentoring.domain.MentoringApplication;
 import com.anchor.domain.mentoring.domain.MentoringUnavailableTime;
 import com.anchor.domain.mentoring.domain.repository.MentoringRepository;
+import com.anchor.domain.mentoring.api.service.response.AppliedMentoringInfo;
+import java.util.List;
+import java.util.NoSuchElementException;
 import com.anchor.domain.mentoring.domain.repository.MentoringUnavailableTimeRepository;
 import com.anchor.domain.payment.domain.Payment;
 import com.anchor.domain.payment.domain.repository.PaymentRepository;
@@ -18,14 +30,13 @@ import com.anchor.domain.user.domain.User;
 import com.anchor.domain.user.domain.repository.UserRepository;
 import com.anchor.global.auth.SessionUser;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
-import java.util.List;
-import java.util.NoSuchElementException;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -38,192 +49,167 @@ public class MentoringService {
     private final PaymentRepository paymentRepository;
     private final PayNumberFactory payNumberFactory;
 
-    @Transactional
-    public MentoringCreateResult create(Long mentorId, MentoringBasicInfo mentoringBasicInfo) {
-        Mentor mentor = getMentorById(mentorId);
-        Mentoring mentoring = Mentoring.createMentoring(mentor, mentoringBasicInfo);
-        Mentoring savedMentoring = mentoringRepository.save(mentoring);
-        return new MentoringCreateResult(savedMentoring.getId());
-    }
+  @Transactional
+  public MentoringCreateResult create(Long mentorId, MentoringBasicInfo mentoringBasicInfo) {
+    Mentor mentor = getMentorById(mentorId);
+    Mentoring mentoring = Mentoring.createMentoring(mentor, mentoringBasicInfo);
+    Mentoring savedMentoring = mentoringRepository.save(mentoring);
+    return new MentoringCreateResult(savedMentoring.getId());
+  }
 
-    @Transactional
-    public MentoringEditResult edit(Long id, MentoringBasicInfo mentoringBasicInfo) {
-        Mentoring mentoring = getMentoringById(id);
-        mentoring.changeBasicInfo(mentoringBasicInfo);
-        Mentoring savedMentoring = mentoringRepository.save(mentoring);
-        return new MentoringEditResult(savedMentoring.getId());
-    }
+  @Transactional
+  public MentoringEditResult edit(Long id, MentoringBasicInfo mentoringBasicInfo) {
+    Mentoring mentoring = getMentoringById(id);
+    mentoring.changeBasicInfo(mentoringBasicInfo);
+    Mentoring savedMentoring = mentoringRepository.save(mentoring);
+    return new MentoringEditResult(savedMentoring.getId());
+  }
 
-    @Transactional
-    public MentoringDeleteResult delete(Long id) {
-        Mentoring mentoring = getMentoringById(id);
-        mentoringRepository.delete(mentoring);
-        return new MentoringDeleteResult(mentoring.getId());
-    }
+  @Transactional
+  public MentoringDeleteResult delete(Long id) {
+    Mentoring mentoring = getMentoringById(id);
+    mentoringRepository.delete(mentoring);
+    return new MentoringDeleteResult(mentoring.getId());
+  }
 
-    @Transactional
-    public MentoringContentsEditResult editContents(Long id, MentoringContentsInfo mentoringContentsInfo) {
-        Mentoring mentoring = getMentoringById(id);
-        mentoring.editContents(mentoringContentsInfo);
-        Mentoring savedMentoring = mentoringRepository.save(mentoring);
-        return new MentoringContentsEditResult(savedMentoring.getId());
-    }
+  @Transactional
+  public MentoringContentsEditResult editContents(Long id, MentoringContentsInfo mentoringContentsInfo) {
+    Mentoring mentoring = getMentoringById(id);
+    mentoring.editContents(mentoringContentsInfo);
+    Mentoring savedMentoring = mentoringRepository.save(mentoring);
+    return new MentoringContentsEditResult(savedMentoring.getId());
+  }
 
-    @Transactional
-    public MentoringContents getContents(Long id) {
-        Mentoring mentoring = getMentoringById(id);
-        return new MentoringContents(mentoring.getContents(), mentoring.getTags());
-    }
+  @Transactional
+  public MentoringContents getContents(Long id) {
+    Mentoring mentoring = getMentoringById(id);
+    return new MentoringContents(mentoring.getContents(), mentoring.getTags());
+  }
 
-    /**
-     * 현재 저장되어있는 모든 멘토링을 조회합니다.
-     */
-    @Transactional(readOnly = true)
-    public List<MentoringDefaultInfo> loadMentoringList() {
-        List<Mentoring> mentoringList = mentoringRepository.findAll();
+  /**
+   * 현재 저장되어있는 모든 멘토링을 조회합니다.
+   */
+  @Transactional(readOnly = true)
+  public List<MentoringDefaultInfo> loadMentoringList() {
+      List<Mentoring> mentoringList = mentoringRepository.findAll();
+      return mentoringList.stream()
+              .map(MentoringDefaultInfo::new)
+              .toList();
+  }
 
-        return mentoringList.stream()
-                .map(MentoringDefaultInfo::new)
-                .toList();
-    }
+  /**
+   * 입력한 ID를 통해 멘토링 상세정보를 조회합니다.
+   */
+  @Transactional(readOnly = true)
+  public MentoringDetailInfo loadMentoringDetail(Long id) {
+      Mentoring findMentoring = getMentoringById(id);
+      return new MentoringDetailInfo(findMentoring);
+  }
 
-    /**
-     * 입력한 ID를 통해 멘토링 상세정보를 조회합니다.
-     */
-    @Transactional(readOnly = true)
-    public MentoringDetailInfo loadMentoringDetail(Long id) {
+  /**
+   * 멘토링 신청페이지 조회시, 신청 불가능한 시간을 데이터베이스에서 조회합니다.
+   */
+  @Transactional(readOnly = true)
+  public List<ApplicationUnavailableTime> loadMentoringUnavailableTime(Long id) {
+      Mentoring findMentoring = getMentoringById(id);
+      List<MentoringUnavailableTime> mentoringUnavailableTime = mentoringUnavailableTimeRepository.findByMentorId(
+              findMentoring.getMentor()
+                      .getId());
+      return mentoringUnavailableTime
+              .isEmpty() ?
+              null :
+              mentoringUnavailableTime
+                      .stream()
+                      .map(ApplicationUnavailableTime::new)
+                      .toList();
+  }
 
-        Mentoring findMentoring = getMentoringById(id);
+  public MentoringPaymentInfo createPaymentInfo(Long mentoringId, MentoringApplicationTime applicationTime) {
+      Mentoring mentoring = getMentoringById(mentoringId);
+      Integer cost = mentoring.getCost();
+      LocalDateTime startDateTime = applicationTime.getFromDateTime();
+      LocalDateTime endDateTime = applicationTime.getToDateTime();
+      String buyerTel = null; // 현재 번호 컬럼이 없으므로 임시로 지정
+      String today = LocalDate.now()
+              .format(DateTimeFormatter.ofPattern("yyyyMMdd"));
+      List<Payment> paymentList = paymentRepository.findPaymentListStartWithToday(today);
+      String merchantUid = payNumberFactory.createMerchantUid(paymentList, today);
+      String impCode = payNumberFactory.getImpCode();
+      return MentoringPaymentInfo.builder()
+              .amount(cost)
+              .impCode(impCode)
+              .merchantUid(merchantUid)
+              .buyerTel(buyerTel)
+              .startDateTime(startDateTime)
+              .endDateTime(endDateTime)
+              .build();
 
-        return new MentoringDetailInfo(findMentoring);
-    }
+  }
 
-    /**
-     * 멘토링 신청페이지 조회시, 신청 불가능한 시간을 데이터베이스에서 조회합니다.
-     */
-    @Transactional(readOnly = true)
-    public List<ApplicationUnavailableTime> loadMentoringUnavailableTime(Long id) {
-
-        Mentoring findMentoring = getMentoringById(id);
-
-        List<MentoringUnavailableTime> mentoringUnavailableTime = mentoringUnavailableTimeRepository.findByMentorId(
-                findMentoring.getMentor()
-                        .getId());
-
-        return mentoringUnavailableTime
-                .isEmpty() ?
-                null :
-                mentoringUnavailableTime
-                        .stream()
-                        .map(ApplicationUnavailableTime::new)
-                        .toList();
-    }
-
-    public MentoringPaymentInfo createPaymentInfo(Long mentoringId, MentoringApplicationTime applicationTime) {
-        Mentoring mentoring = getMentoringById(mentoringId);
-
-        Integer cost = mentoring.getCost();
-
-        LocalDateTime startDateTime = applicationTime.getFromDateTime();
-        LocalDateTime endDateTime = applicationTime.getToDateTime();
-
-        String buyerTel = null; // 현재 번호 컬럼이 없으므로 임시로 지정
-
-        String today = LocalDate.now()
-                .format(DateTimeFormatter.ofPattern("yyyyMMdd"));
-
-        List<Payment> paymentList = paymentRepository.findPaymentListStartWithToday(today);
-
-        String merchantUid = payNumberFactory.createMerchantUid(paymentList, today);
-
-        String impCode = payNumberFactory.getImpCode();
-
-        return MentoringPaymentInfo.builder()
-                .amount(cost)
-                .impCode(impCode)
-                .merchantUid(merchantUid)
-                .buyerTel(buyerTel)
-                .startDateTime(startDateTime)
-                .endDateTime(endDateTime)
-                .build();
-
-    }
-
-
-    /**
-     * 멘토링 신청이 완료되면 멘토링 신청내역을 저장합니다.
-     */
-    @Transactional
-    public AppliedMentoringInfo saveMentoringApplication(SessionUser sessionUser,
-                                                         Long mentoringId, MentoringApplicationInfo applicationInfo) {
-
-        Mentoring findMentoring = getMentoringById(mentoringId);
-
-        User loginUser = getUser(sessionUser);
-
-        MentoringApplication mentoringApplication =
-                new MentoringApplication(applicationInfo, null, findMentoring, null, loginUser);
-
-        Payment payment = new Payment(applicationInfo, mentoringApplication);
-
-        paymentRepository.save(payment);
-
-        saveMentoringUnavailableTime(mentoringApplication, findMentoring);
-
-        return new AppliedMentoringInfo(mentoringApplication, payment);
-    }
+  /**
+   * 멘토링 신청이 완료되면 멘토링 신청내역을 저장합니다.
+   */
+  @Transactional
+  public AppliedMentoringInfo saveMentoringApplication(SessionUser sessionUser,
+                                                       Long mentoringId, MentoringApplicationInfo applicationInfo) {
+      Mentoring findMentoring = getMentoringById(mentoringId);
+      User loginUser = getUser(sessionUser);
+      MentoringApplication mentoringApplication =
+              new MentoringApplication(applicationInfo, null, findMentoring, null, loginUser);
+      Payment payment = new Payment(applicationInfo, mentoringApplication);
+      paymentRepository.save(payment);
+      saveMentoringUnavailableTime(mentoringApplication, findMentoring);
+      return new AppliedMentoringInfo(mentoringApplication, payment);
+  }
 
 
-    public void addApplicationTimeFromSession
-            (List<ApplicationUnavailableTime> sessionList, MentoringApplicationTime applicationTime) {
+  public void addApplicationTimeFromSession
+          (List<ApplicationUnavailableTime> sessionList, MentoringApplicationTime applicationTime) {
+      ApplicationUnavailableTime targetMentoringApplicationUnavailableTime = applicationTime.convertToMentoringUnavailableTimeResponse();
+      if (!sessionList.contains(targetMentoringApplicationUnavailableTime)) {
+          sessionList.add(targetMentoringApplicationUnavailableTime);
+      }
+  }
 
-        ApplicationUnavailableTime targetMentoringApplicationUnavailableTime = applicationTime.convertToMentoringUnavailableTimeResponse();
+  public boolean removeApplicationTimeFromSession
+          (List<ApplicationUnavailableTime> sessionList, MentoringApplicationTime applicationTime) {
+      ApplicationUnavailableTime targetMentoringApplicationUnavailableTime = applicationTime.convertToMentoringUnavailableTimeResponse();
+      return sessionList.remove(targetMentoringApplicationUnavailableTime);
+  }
 
-        if (!sessionList.contains(targetMentoringApplicationUnavailableTime)) {
-            sessionList.add(targetMentoringApplicationUnavailableTime);
-        }
-    }
+  public void removeApplicationTimeFromSession
+          (List<ApplicationUnavailableTime> sessionList, MentoringApplicationInfo applicationInfo) {
+      ApplicationUnavailableTime targetMentoringApplicationUnavailableTime = ApplicationUnavailableTime.builder()
+              .fromDateTime(applicationInfo.getStartDateTime())
+              .toDateTime(applicationInfo.getEndDateTime())
+              .build();
+      sessionList.remove(targetMentoringApplicationUnavailableTime);
+  }
 
-    public boolean removeApplicationTimeFromSession
-            (List<ApplicationUnavailableTime> sessionList, MentoringApplicationTime applicationTime) {
+  private Mentor getMentorById(Long id) {
+      return mentorRepository.findById(id)
+              .orElseThrow(() -> new NoSuchElementException("일치하는 멘토 정보가 없습니다."));
+  }
 
-        ApplicationUnavailableTime targetMentoringApplicationUnavailableTime = applicationTime.convertToMentoringUnavailableTimeResponse();
+  private Mentoring getMentoringById(Long id) {
+      return mentoringRepository.findById(id)
+              .orElseThrow(() -> new NoSuchElementException(id + "에 해당하는 멘토링이 존재하지 않습니다."));
+  }
 
-        return sessionList.remove(targetMentoringApplicationUnavailableTime);
-    }
+  private User getUser(SessionUser sessionUser) {
+      return userRepository.findByEmail(sessionUser.getEmail())
+              .orElseThrow(() -> new NoSuchElementException(sessionUser.getEmail() + "에 해당하는 회원이 존재하지 않습니다."));
+  }
 
-    public void removeApplicationTimeFromSession
-            (List<ApplicationUnavailableTime> sessionList, MentoringApplicationInfo applicationInfo) {
+  @Transactional
+  public Page<MentoringSearchResult> getMentorings(List<String> tags, String keyword, Pageable pageable) {
+    return mentoringRepository.findMentorings(tags, keyword, pageable);
+  }
 
-        ApplicationUnavailableTime targetMentoringApplicationUnavailableTime = ApplicationUnavailableTime.builder()
-                .fromDateTime(applicationInfo.getStartDateTime())
-                .toDateTime(applicationInfo.getEndDateTime())
-                .build();
+  private void saveMentoringUnavailableTime(MentoringApplication mentoringApplication, Mentoring findMentoring) {
+      MentoringUnavailableTime saveMentoringUnavailableTime =
+              new MentoringUnavailableTime(mentoringApplication, findMentoring);
+      mentoringUnavailableTimeRepository.save(saveMentoringUnavailableTime);
+  }
 
-        sessionList.remove(targetMentoringApplicationUnavailableTime);
-    }
-
-
-    private Mentor getMentorById(Long id) {
-        return mentorRepository.findById(id)
-                .orElseThrow(() -> new NoSuchElementException("일치하는 멘토 정보가 없습니다."));
-    }
-
-    private Mentoring getMentoringById(Long id) {
-        return mentoringRepository.findById(id)
-                .orElseThrow(() -> new NoSuchElementException(id + "에 해당하는 멘토링이 존재하지 않습니다."));
-    }
-
-    private User getUser(SessionUser sessionUser) {
-        return userRepository.findByEmail(sessionUser.getEmail())
-                .orElseThrow(() -> new NoSuchElementException(sessionUser.getEmail() + "에 해당하는 회원이 존재하지 않습니다."));
-    }
-
-    private void saveMentoringUnavailableTime(MentoringApplication mentoringApplication, Mentoring findMentoring) {
-
-        MentoringUnavailableTime saveMentoringUnavailableTime =
-                new MentoringUnavailableTime(mentoringApplication, findMentoring);
-
-        mentoringUnavailableTimeRepository.save(saveMentoringUnavailableTime);
-    }
 }

--- a/src/main/java/com/anchor/domain/mentoring/api/service/response/MentoringSearchResult.java
+++ b/src/main/java/com/anchor/domain/mentoring/api/service/response/MentoringSearchResult.java
@@ -1,0 +1,104 @@
+package com.anchor.domain.mentoring.api.service.response;
+
+import com.anchor.domain.mentor.domain.Mentor;
+import com.anchor.domain.mentoring.domain.Mentoring;
+import com.anchor.domain.mentoring.domain.MentoringTag;
+import com.anchor.domain.user.domain.User;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MentoringSearchResult {
+
+  private MentorInfo mentorInfo;
+  private MentoringInfo mentoringInfo;
+
+  @Builder
+  private MentoringSearchResult(
+      MentorInfo mentorInfo,
+      MentoringInfo mentoringInfo
+  ) {
+    this.mentorInfo = mentorInfo;
+    this.mentoringInfo = mentoringInfo;
+  }
+
+  public static MentoringSearchResult of(Mentoring mentoring) {
+    Mentor mentor = mentoring.getMentor();
+    User user = mentor.getUser();
+    return MentoringSearchResult.builder()
+        .mentorInfo(MentorInfo.of(mentor, user))
+        .mentoringInfo(MentoringInfo.of(mentoring))
+        .build();
+  }
+
+  @Getter
+  @NoArgsConstructor
+  static class MentorInfo {
+
+    private Long id;
+    private String mentorImage;
+    private String mentorNickname;
+    private String career;
+    private String companyEmail;
+
+    @Builder
+    private MentorInfo(Long id, String mentorImage, String mentorNickname, String career, String companyEmail) {
+      this.id = id;
+      this.mentorImage = mentorImage;
+      this.mentorNickname = mentorNickname;
+      this.career = career;
+      this.companyEmail = companyEmail;
+    }
+
+    public static MentorInfo of(Mentor mentor, User user) {
+      return MentorInfo.builder()
+          .id(mentor.getId())
+          .career(mentor.getCareer()
+              .getRangeOfYear())
+          .mentorImage(user.getImage())
+          .mentorNickname(user.getNickname())
+          .companyEmail(mentor.getCompanyEmail())
+          .build();
+    }
+
+  }
+
+  @Getter
+  @NoArgsConstructor
+  static class MentoringInfo {
+
+    private String title;
+    private String durationTime;
+    private Integer cost;
+    private Integer totalApplicationNumber;
+    private List<String> mentoringTags;
+
+    @Builder
+    private MentoringInfo(String title, String durationTime, Integer cost, Integer totalApplicationNumber,
+        List<String> mentoringTags) {
+      this.title = title;
+      this.durationTime = durationTime;
+      this.cost = cost;
+      this.totalApplicationNumber = totalApplicationNumber;
+      this.mentoringTags = mentoringTags;
+    }
+
+    public static MentoringInfo of(Mentoring mentoring) {
+      return MentoringInfo.builder()
+          .title(mentoring.getTitle())
+          .durationTime(mentoring.getDurationTime())
+          .totalApplicationNumber(mentoring.getTotalApplicationNumber())
+          .mentoringTags(mentoring.getMentoringTags()
+              .stream()
+              .map(MentoringTag::getTag)
+              .toList())
+          .cost(mentoring.getCost())
+          .build();
+    }
+
+  }
+
+}

--- a/src/main/java/com/anchor/domain/mentoring/domain/Mentoring.java
+++ b/src/main/java/com/anchor/domain/mentoring/domain/Mentoring.java
@@ -108,10 +108,10 @@ public class Mentoring extends BaseEntity {
     Set<String> savedTags = this.mentoringTags.stream()
         .map(MentoringTag::getTag)
         .collect(Collectors.toSet());
-    ArrayList<String> mutableTags = new ArrayList<>(tags);
+    List<String> mutableTags = new ArrayList<>(tags);
     mutableTags.removeAll(savedTags);
     this.mentoringTags.addAll(mutableTags.stream()
-        .map(MentoringTag::new)
+        .map(tag -> new MentoringTag(tag, this))
         .collect(Collectors.toSet()));
   }
 

--- a/src/main/java/com/anchor/domain/mentoring/domain/MentoringTag.java
+++ b/src/main/java/com/anchor/domain/mentoring/domain/MentoringTag.java
@@ -22,8 +22,9 @@ public class MentoringTag extends BaseEntity {
   @JoinColumn(name = "mentoring_id")
   private Mentoring mentoring;
 
-  public MentoringTag(String tag) {
+  public MentoringTag(String tag, Mentoring mentoring) {
     this.tag = tag;
+    this.mentoring = mentoring;
   }
 
 }

--- a/src/main/java/com/anchor/domain/mentoring/domain/repository/MentoringRepository.java
+++ b/src/main/java/com/anchor/domain/mentoring/domain/repository/MentoringRepository.java
@@ -1,10 +1,11 @@
 package com.anchor.domain.mentoring.domain.repository;
 
 import com.anchor.domain.mentoring.domain.Mentoring;
+import com.anchor.domain.mentoring.domain.repository.custom.QMentoringRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface MentoringRepository extends JpaRepository<Mentoring, Long> {
+public interface MentoringRepository extends JpaRepository<Mentoring, Long>, QMentoringRepository {
 
 }

--- a/src/main/java/com/anchor/domain/mentoring/domain/repository/custom/QMentoringApplicationRepositoryImpl.java
+++ b/src/main/java/com/anchor/domain/mentoring/domain/repository/custom/QMentoringApplicationRepositoryImpl.java
@@ -5,14 +5,12 @@ import com.anchor.domain.mentoring.domain.MentoringStatus;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
-
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
-
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 import static com.anchor.domain.mentoring.domain.QMentoring.mentoring;
 import static com.anchor.domain.mentoring.domain.QMentoringApplication.mentoringApplication;
 import static com.anchor.domain.payment.domain.QPayment.payment;
@@ -21,91 +19,90 @@ import static com.anchor.domain.payment.domain.QPayment.payment;
 @Repository
 public class QMentoringApplicationRepositoryImpl implements QMentoringApplicationRepository {
 
-    private final JPAQueryFactory jpaQueryFactory;
+  private final JPAQueryFactory jpaQueryFactory;
 
-    @Override
-    public MentoringApplication findByMentoringIdAndProgressTime(
-            Long mentoringId, LocalDateTime startDateTime, LocalDateTime endDateTime) {
-        return jpaQueryFactory.selectFrom(mentoringApplication)
-                .where(
-                        mentoringApplication.mentoring.id.eq(mentoringId)
-                                .and(
-                                        mentoringApplication.startDateTime.eq(startDateTime))
-                                .and(mentoringApplication.endDateTime.eq(endDateTime)))
-                .fetchOne();
-    }
+  @Override
+  public MentoringApplication findByMentoringIdAndProgressTime(Long mentoringId,
+      LocalDateTime startDateTime, LocalDateTime endDateTime) {
+    return jpaQueryFactory.selectFrom(mentoringApplication)
+        .where(mentoringApplication.mentoring.id.eq(mentoringId)
+            .and(mentoringApplication.startDateTime.eq(startDateTime))
+            .and(mentoringApplication.endDateTime.eq(endDateTime)))
+        .fetchOne();
+  }
 
-    @Override
-    public List<MentoringApplication> findTimesByMentoringIdAndStatus(
-            Long mentorId, MentoringStatus... statuses) {
-        return jpaQueryFactory.selectFrom(mentoringApplication)
-                .where(mentoringApplication.mentoring.mentor.id.eq(mentorId).and(statusOr(statuses))).fetch();
-    }
+  @Override
+  public List<MentoringApplication> findTimesByMentoringIdAndStatus(Long mentorId, MentoringStatus... statuses) {
+    return jpaQueryFactory.selectFrom(mentoringApplication)
+        .where(mentoringApplication.mentoring.mentor.id.eq(mentorId)
+            .and(equalsStatuses(statuses)))
+        .fetch();
+  }
 
-    @Override
-    public Optional<MentoringApplication> findAppliedMentoringByTimeAndUserId(
-            LocalDateTime startDateTime,
-            LocalDateTime endDateTime, Long userId) {
+  @Override
+  public Optional<MentoringApplication> findAppliedMentoringByTimeAndUserId(
+          LocalDateTime startDateTime,
+          LocalDateTime endDateTime, Long userId) {
 
-        return Optional.ofNullable(
-                jpaQueryFactory.selectFrom(mentoringApplication)
-                        .join(mentoringApplication.mentoring, mentoring)
-                        .fetchJoin()
-                        .join(mentoringApplication.payment, payment)
-                        .fetchJoin()
-                        .where(mentoringApplication.startDateTime.eq(startDateTime)
-                                .and(mentoringApplication.endDateTime.eq(endDateTime))
-                                .and(mentoringApplication.user.id.eq(userId))
-                        )
-                        .fetchOne());
+      return Optional.ofNullable(
+              jpaQueryFactory.selectFrom(mentoringApplication)
+                      .join(mentoringApplication.mentoring, mentoring)
+                      .fetchJoin()
+                      .join(mentoringApplication.payment, payment)
+                      .fetchJoin()
+                      .where(mentoringApplication.startDateTime.eq(startDateTime)
+                              .and(mentoringApplication.endDateTime.eq(endDateTime))
+                              .and(mentoringApplication.user.id.eq(userId))
+                      )
+                      .fetchOne());
 
-    }
+  }
 
-    @Override
-    public Optional<MentoringApplication> findMentoringApplicationByTimeRangeAndUserId
-            (LocalDateTime startDateTime, LocalDateTime endDateTime, Long userId) {
-        return Optional.ofNullable(
-                jpaQueryFactory.selectFrom(mentoringApplication)
-                        .join(mentoringApplication.payment, payment)
-                        .fetchJoin()
-                        .where(mentoringApplication.startDateTime.eq(startDateTime)
-                                .and(mentoringApplication.endDateTime.eq(endDateTime))
-                                .and(mentoringApplication.user.id.eq(userId)))
-                        .fetchOne()
-        );
-    }
+  @Override
+  public Optional<MentoringApplication> findMentoringApplicationByTimeRangeAndUserId
+          (LocalDateTime startDateTime, LocalDateTime endDateTime, Long userId) {
+      return Optional.ofNullable(
+              jpaQueryFactory.selectFrom(mentoringApplication)
+                      .join(mentoringApplication.payment, payment)
+                      .fetchJoin()
+                      .where(mentoringApplication.startDateTime.eq(startDateTime)
+                              .and(mentoringApplication.endDateTime.eq(endDateTime))
+                              .and(mentoringApplication.user.id.eq(userId)))
+                      .fetchOne()
+      );
+  }
 
-    @Override
-    public Optional<MentoringApplication> findMentoringApplicationByMentoringId(
-            LocalDateTime startDateTime,
-            LocalDateTime endDateTime, Long mentoringId) {
+  @Override
+  public Optional<MentoringApplication> findMentoringApplicationByMentoringId(
+          LocalDateTime startDateTime,
+          LocalDateTime endDateTime, Long mentoringId) {
 
-        return Optional.ofNullable(
-                jpaQueryFactory.selectFrom(mentoringApplication)
-                        .join(mentoringApplication.payment, payment)
-                        .fetchJoin()
-                        .where(mentoringApplication.startDateTime.eq(startDateTime)
-                                .and(mentoringApplication.endDateTime.eq(endDateTime))
-                                .and(mentoringApplication.mentoring.id.eq(mentoringId)))
-                        .fetchOne()
-        );
-    }
+      return Optional.ofNullable(
+              jpaQueryFactory.selectFrom(mentoringApplication)
+                      .join(mentoringApplication.payment, payment)
+                      .fetchJoin()
+                      .where(mentoringApplication.startDateTime.eq(startDateTime)
+                              .and(mentoringApplication.endDateTime.eq(endDateTime))
+                              .and(mentoringApplication.mentoring.id.eq(mentoringId)))
+                      .fetchOne()
+      );
+  }
 
-    private BooleanBuilder statusOr(MentoringStatus... statuses) {
-        BooleanBuilder builder = new BooleanBuilder();
-        Arrays.stream(statuses)
-                .map(this::equalStatus)
-                .forEach(builder::or);
-        return builder;
-    }
+  private BooleanBuilder equalsStatuses(MentoringStatus... statuses) {
+    BooleanBuilder builder = new BooleanBuilder();
+    Arrays.stream(statuses)
+        .map(this::equalStatus)
+        .forEach(builder::or);
+    return builder;
+  }
 
-    private BooleanExpression equalStatus(MentoringStatus status) {
-        return switch (status) {
-            case CANCELLED -> mentoringApplication.mentoringStatus.eq(MentoringStatus.CANCELLED);
-            case WAITING -> mentoringApplication.mentoringStatus.eq(MentoringStatus.WAITING);
-            case COMPLETE -> mentoringApplication.mentoringStatus.eq(MentoringStatus.COMPLETE);
-            case APPROVAL -> mentoringApplication.mentoringStatus.eq(MentoringStatus.APPROVAL);
-        };
-    }
+  private BooleanExpression equalStatus(MentoringStatus status) {
+    return switch (status) {
+      case CANCELLED -> mentoringApplication.mentoringStatus.eq(MentoringStatus.CANCELLED);
+      case WAITING -> mentoringApplication.mentoringStatus.eq(MentoringStatus.WAITING);
+      case COMPLETE -> mentoringApplication.mentoringStatus.eq(MentoringStatus.COMPLETE);
+      case APPROVAL -> mentoringApplication.mentoringStatus.eq(MentoringStatus.APPROVAL);
+    };
+  }
 
 }

--- a/src/main/java/com/anchor/domain/mentoring/domain/repository/custom/QMentoringRepository.java
+++ b/src/main/java/com/anchor/domain/mentoring/domain/repository/custom/QMentoringRepository.java
@@ -1,0 +1,12 @@
+package com.anchor.domain.mentoring.domain.repository.custom;
+
+import com.anchor.domain.mentoring.api.service.response.MentoringSearchResult;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface QMentoringRepository {
+
+  Page<MentoringSearchResult> findMentorings(List<String> tags, String keyword, Pageable pageable);
+
+}

--- a/src/main/java/com/anchor/domain/mentoring/domain/repository/custom/QMentoringRepositoryImpl.java
+++ b/src/main/java/com/anchor/domain/mentoring/domain/repository/custom/QMentoringRepositoryImpl.java
@@ -1,0 +1,83 @@
+package com.anchor.domain.mentoring.domain.repository.custom;
+
+import static com.anchor.domain.mentoring.domain.QMentoring.mentoring;
+
+import com.anchor.domain.mentoring.api.service.response.MentoringSearchResult;
+import com.anchor.domain.mentoring.domain.Mentoring;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Predicate;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@RequiredArgsConstructor
+@Repository
+public class QMentoringRepositoryImpl implements QMentoringRepository {
+
+  private final JPAQueryFactory jpaQueryFactory;
+
+  public Page<MentoringSearchResult> findMentorings(List<String> tags, String keyword, Pageable pageable) {
+    List<Long> mentoringIds = jpaQueryFactory.select(mentoring.id)
+        .from(mentoring)
+        .where(
+            containsTitle(keyword).or(containsContents(keyword))
+                .and(equalTags(tags))
+        )
+        .offset(pageable.getOffset())
+        .limit(pageable.getPageSize())
+        .fetch();
+
+    List<Mentoring> result = jpaQueryFactory.selectFrom(mentoring)
+        .innerJoin(mentoring.mentor)
+        .fetchJoin()
+        .innerJoin(mentoring.mentoringTags)
+        .fetchJoin()
+        .innerJoin(mentoring.mentor.user)
+        .fetchJoin()
+        .where(
+            mentoring.id.in(mentoringIds)
+        )
+        .fetch();
+
+    List<MentoringSearchResult> mentoringSearchResults = result.stream()
+        .map(MentoringSearchResult::of)
+        .toList();
+
+    return new PageImpl<>(mentoringSearchResults, pageable, mentoringSearchResults.size());
+  }
+
+  private Predicate containsContents(String keyword) {
+    if (keyword != null && !keyword.isBlank()) {
+      return mentoring.mentoringDetail.contents.contains(keyword);
+    }
+    return null;
+  }
+
+  private BooleanExpression containsTitle(String keyword) {
+    if (keyword != null && !keyword.isBlank()) {
+      return mentoring.title.contains(keyword);
+    }
+    return null;
+  }
+
+  private BooleanBuilder equalTags(List<String> tags) {
+    BooleanBuilder builder = new BooleanBuilder();
+    tags.stream()
+        .map(this::equalTag)
+        .forEach(builder::or);
+    return builder;
+  }
+
+  private BooleanExpression equalTag(String tag) {
+    if (tag != null && !tag.isBlank()) {
+      return mentoring.mentoringTags.any().tag.eq(tag);
+    }
+    return null;
+  }
+
+}

--- a/src/main/java/com/anchor/domain/user/domain/User.java
+++ b/src/main/java/com/anchor/domain/user/domain/User.java
@@ -8,7 +8,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
@@ -35,7 +34,6 @@ public class User extends BaseEntity {
   private UserRole role;
 
   @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "mentor_id")
   private Mentor mentor;
 
   @OneToMany(mappedBy = "user")

--- a/src/test/java/com/anchor/domain/mentoring/api/service/MentoringDataTest.java
+++ b/src/test/java/com/anchor/domain/mentoring/api/service/MentoringDataTest.java
@@ -1,18 +1,29 @@
 package com.anchor.domain.mentoring.api.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.anchor.domain.mentor.domain.Career;
 import com.anchor.domain.mentor.domain.Mentor;
 import com.anchor.domain.mentor.domain.repository.MentorRepository;
 import com.anchor.domain.mentoring.api.controller.request.MentoringContentsInfo;
+import com.anchor.domain.mentoring.api.service.response.MentoringSearchResult;
 import com.anchor.domain.mentoring.domain.Mentoring;
 import com.anchor.domain.mentoring.domain.MentoringDetail;
 import com.anchor.domain.mentoring.domain.MentoringTag;
 import com.anchor.domain.mentoring.domain.repository.MentoringRepository;
+import com.anchor.domain.user.domain.User;
+import com.anchor.domain.user.domain.UserRole;
+import com.anchor.domain.user.domain.repository.UserRepository;
 import com.anchor.global.config.QueryDslConfig;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.micrometer.common.util.internal.logging.InternalLogger;
+import io.micrometer.common.util.internal.logging.Slf4JLoggerFactory;
 import jakarta.transaction.Transactional;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import org.assertj.core.api.Assertions;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,14 +31,20 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort.Direction;
 import org.springframework.test.context.ActiveProfiles;
 
 @DisplayName("멘토링 서비스 테스트 - DB 의존성 포함")
-@Import({QueryDslConfig.class, MentoringService.class})
+@Import({QueryDslConfig.class, MentoringService.class, ObjectMapper.class})
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @ActiveProfiles("test")
 @DataJpaTest
 public class MentoringDataTest {
+
+  @Autowired
+  UserRepository userRepository;
 
   @Autowired
   MentoringService mentoringService;
@@ -37,6 +54,9 @@ public class MentoringDataTest {
 
   @Autowired
   MentorRepository mentorRepository;
+
+  @Autowired
+  ObjectMapper objectMapper;
 
   @Transactional
   @DisplayName("멘토링 아이디를 이용해 멘토링 상세 내용과 태그들을 등록합니다.")
@@ -71,11 +91,11 @@ public class MentoringDataTest {
     MentoringDetail mentoringDetail = updatedMentoring.getMentoringDetail();
     Set<MentoringTag> mentoringTags = updatedMentoring.getMentoringTags();
 
-    Assertions.assertThat(mentoringDetail)
+    assertThat(mentoringDetail)
         .extracting("contents")
         .isEqualTo("<h1>컨텐츠입니다.<h1>");
 
-    Assertions.assertThat(mentoringTags)
+    assertThat(mentoringTags)
         .extracting("tag")
         .contains("java", "spring");
   }
@@ -114,11 +134,11 @@ public class MentoringDataTest {
     MentoringDetail mentoringDetail = updatedMentoring.getMentoringDetail();
     Set<MentoringTag> mentoringTags = updatedMentoring.getMentoringTags();
 
-    Assertions.assertThat(mentoringDetail)
+    assertThat(mentoringDetail)
         .extracting("contents")
         .isEqualTo("<h1>수정된 컨텐츠입니다.<h1>");
 
-    Assertions.assertThat(mentoringTags)
+    assertThat(mentoringTags)
         .extracting("tag")
         .contains("java", "spring", "boot");
   }
@@ -155,8 +175,68 @@ public class MentoringDataTest {
     mentoringService.delete(updatedMentoring.getId());
 
     // then
-    Assertions.assertThat(mentoringRepository.findById(updatedMentoring.getId()))
+    assertThat(mentoringRepository.findById(updatedMentoring.getId()))
         .isEmpty();
+  }
+
+  @Transactional
+  @DisplayName("검색 조건을 통해 멘토링 목록을 조회합니다.")
+  @Test
+  void testName() throws JsonProcessingException {
+    // given
+    User user = User.builder()
+        .email("qwer@naver.com")
+        .nickname("홍길동")
+        .role(UserRole.MENTOR)
+        .build();
+    User savedUser = userRepository.save(user);
+
+    Mentor mentor = Mentor.builder()
+        .companyEmail("company@navercorp.com")
+        .accountName("홍길동")
+        .accountNumber("123412341234")
+        .bankName("한국은행")
+        .career(Career.MIDDLE)
+        .user(savedUser)
+        .build();
+    Mentor savedMentor = mentorRepository.save(mentor);
+
+    List<String> tagList = List.of("java", "spring", "docker", "redis", "data");
+    List<Mentoring> mentorings = new ArrayList<>();
+    for (int count = 1; count < 50; count++) {
+      int skip = count % 5;
+      List<String> tags = IntStream.range(0, 5)
+          .filter(i -> i != skip)
+          .mapToObj(tagList::get)
+          .toList();
+
+      Mentoring mentoring = Mentoring.builder()
+          .title("제목" + count)
+          .durationTime("1h")
+          .cost(10000)
+          .mentor(savedMentor)
+          .build();
+
+      mentoring.editContents(MentoringContentsInfo.builder()
+          .contents("하이용, 내용입니다." + count)
+          .tags(tags)
+          .build());
+      mentorings.add(mentoring);
+    }
+    mentoringRepository.saveAll(mentorings);
+
+    // when
+    PageRequest pageRequest = PageRequest
+        .of(0, 16, Direction.DESC, "id", "totalApplicationNumber");
+    Page<MentoringSearchResult> results = mentoringService.getMentorings(List.of("java", "docker"), "제목",
+        pageRequest);
+
+    // then
+    assertThat(results.getTotalElements()).isEqualTo(16);
+    InternalLogger log = Slf4JLoggerFactory.getInstance("TestLog");
+    String result = objectMapper.writeValueAsString(results);
+    log.info("{}", result);
+
   }
 
 }


### PR DESCRIPTION
# 1. Abtract
- 멘토링 검색 기능을 구현 및 테스트했습니다.

# 2. Detail of Changes
## 2-1. 검색 기능 설명
- 검색 키워드와 태그들을 활용해서 검색할 수 있습니다.
- 페이징 처리를 통해 페이지당 기본 16개의 멘토링 리스트를 응답합니다.
- 멘토 정보와 멘토링 정보를 포함합니다.

## 2-2. 이슈 및 개선사항
### 상황
```
HHH90003004: firstResult/maxResults specified with collection fetch; applying in memory
```
fetch join과 pagination을 함께 사용하는 상황에서 위와 같은 경고가 발생했습니다.
### 원인
모든 일치하는 데이터를 어플리케이션에 가져와 페이징 처리를 수행합니다.
데이터가 많다면 불필요한 메모리 부하가 발생할 수 있습니다.
### 해결 방법
```
    List<Long> mentoringIds = jpaQueryFactory.select(mentoring.id)
        .from(mentoring)
        .where(
            containsTitle(keyword).or(containsContents(keyword))
                .and(equalTags(tags))
        )
        .offset(pageable.getOffset())
        .limit(pageable.getPageSize())
        .fetch();

    List<Mentoring> result = jpaQueryFactory.selectFrom(mentoring)
        .innerJoin(mentoring.mentor)
        .fetchJoin()
        .innerJoin(mentoring.mentoringTags)
        .fetchJoin()
        .innerJoin(mentoring.mentor.user)
        .fetchJoin()
        .where(
            mentoring.id.in(mentoringIds)
        )
        .fetch();
```
- 조건에 맞는 Mentoring Id를 받아오는 쿼리문
- 엔티티에 필요한 모든 데이터를 받아오는 Join 쿼리문

위와 같이 쿼리문을 2개로 분리해 조회해올 Mentoring 객체에 대한 Id를 먼저 받아온 후,
해당 Id를 통해 Join해 필요한 엔티티들에 대한 데이터를 주입합니다.

# 3. To Others

# 4. Q&A