### PR TITLE
feature: 멘토링 검색 기능 보완

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'com.github.ben-manes.caffeine:caffeine:3.1.8'
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/anchor/AnchorApplication.java
+++ b/src/main/java/com/anchor/AnchorApplication.java
@@ -5,9 +5,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableAsync;
 
+@EnableAsync
 @EnableJpaAuditing
 @SpringBootApplication
-@EnableAsync
 public class AnchorApplication {
 
   public static void main(String[] args) {

--- a/src/main/java/com/anchor/domain/mentoring/api/controller/MentoringViewController.java
+++ b/src/main/java/com/anchor/domain/mentoring/api/controller/MentoringViewController.java
@@ -32,7 +32,7 @@ public class MentoringViewController {
       @RequestParam(value = "tag", required = false) List<String> tags,
       @RequestParam(value = "keyword", required = false) String keyword,
       @PageableDefault(size = 16,
-          sort = {"id", "totalApplicationNumber"}, direction = Sort.Direction.DESC) Pageable pageable,
+          sort = {"totalApplicationNumber"}, direction = Sort.Direction.DESC) Pageable pageable,
       Model model
   ) {
     Page<MentoringSearchResult> result = mentoringService.getMentorings(tags, keyword, pageable);

--- a/src/main/java/com/anchor/domain/mentoring/api/service/MentoringService.java
+++ b/src/main/java/com/anchor/domain/mentoring/api/service/MentoringService.java
@@ -32,6 +32,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -208,6 +209,7 @@ public class MentoringService {
     return mentoringRepository.findMentorings(tags, keyword, pageable);
   }
 
+  @Cacheable(cacheNames = "topMentoring", key = "'topMentoring'")
   @Transactional(readOnly = true)
   public TopMentoring getTopMentorings() {
     List<MentoringSearchResult> topMentorings = mentoringRepository.findTopMentorings();

--- a/src/main/java/com/anchor/domain/mentoring/domain/repository/custom/QMentoringRepositoryImpl.java
+++ b/src/main/java/com/anchor/domain/mentoring/domain/repository/custom/QMentoringRepositoryImpl.java
@@ -1,19 +1,25 @@
 package com.anchor.domain.mentoring.domain.repository.custom;
 
 import static com.anchor.domain.mentoring.domain.QMentoring.mentoring;
+import static com.querydsl.core.types.dsl.Expressions.numberTemplate;
 
 import com.anchor.domain.mentoring.api.service.response.MentoringSearchResult;
 import com.anchor.domain.mentoring.domain.Mentoring;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
+import com.querydsl.core.types.dsl.NumberExpression;
+import com.querydsl.core.types.dsl.NumberTemplate;
 import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.core.types.dsl.StringPath;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
@@ -22,22 +28,42 @@ import org.springframework.stereotype.Repository;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.StringUtils;
 
+@Slf4j
 @RequiredArgsConstructor
 @Repository
 public class QMentoringRepositoryImpl implements QMentoringRepository {
 
   private final JPAQueryFactory jpaQueryFactory;
+  private final ObjectMapper objectMapper;
 
+  private static NumberTemplate<Double> getScore(StringPath target, String keyword) {
+    return numberTemplate(Double.class, "function('match_against', {0}, {1})",
+        target, keyword);
+  }
+
+  /*
+   * 조건에 맞는 멘토링을 검색한 결과 값을 가져옵니다.
+   *
+   * 1차 정렬 기준은 다음과 같습니다.
+   * 기준 1. 입력받은 키워드와 멘토링 제목 및 내용이 일치하는 정도를 기준으로 내림차순
+   * 기준 2. 아이디를 기준으로 내림차순 (= 최신 멘토링 등록순)
+   *
+   * 2차 정렬 기준은 다음과 같습니다.
+   * 기준 1. 멘토링 신청자 수를 기준으로 내림차순
+   *
+   * (참고로 2차 정렬은 요청에 따라 달라집니다.)
+   */
   public Page<MentoringSearchResult> findMentorings(List<String> tags, String keyword, Pageable pageable) {
+    Searchable searchable = Searchable.of(keyword);
     List<Long> mentoringIds = jpaQueryFactory.select(mentoring.id)
         .from(mentoring)
         .where(
-            containsTitle(keyword)
-                .or(containsContents(keyword))
-                .and(equalTags(tags))
+            (searchable.getCondition())
+                .and(equalsWith(tags))
         )
-        .offset(pageable.getOffset())
-        .limit(pageable.getPageSize())
+        .orderBy(searchable.getSort())
+        .offset(from(pageable))
+        .limit(to(pageable))
         .fetch();
 
     List<Mentoring> result = jpaQueryFactory.selectFrom(mentoring)
@@ -77,6 +103,14 @@ public class QMentoringRepositoryImpl implements QMentoringRepository {
     return topMentorings;
   }
 
+  private long from(Pageable pageable) {
+    return pageable.getOffset();
+  }
+
+  private long to(Pageable pageable) {
+    return from(pageable) + pageable.getPageSize();
+  }
+
   private OrderSpecifier[] getOrderSpecifier(Sort sort) {
     List<OrderSpecifier> orders = new ArrayList<>();
     sort.stream()
@@ -89,21 +123,7 @@ public class QMentoringRepositoryImpl implements QMentoringRepository {
     return orders.toArray(OrderSpecifier[]::new);
   }
 
-  private BooleanExpression containsTitle(String keyword) {
-    if (StringUtils.hasText(keyword)) {
-      return mentoring.title.contains(keyword);
-    }
-    return Expressions.TRUE;
-  }
-
-  private BooleanExpression containsContents(String keyword) {
-    if (StringUtils.hasText(keyword)) {
-      return mentoring.mentoringDetail.contents.contains(keyword);
-    }
-    return Expressions.TRUE;
-  }
-
-  private BooleanBuilder equalTags(List<String> tags) {
+  private BooleanBuilder equalsWith(List<String> tags) {
     BooleanBuilder builder = new BooleanBuilder();
     if (!CollectionUtils.isEmpty(tags)) {
       tags.stream()
@@ -118,6 +138,39 @@ public class QMentoringRepositoryImpl implements QMentoringRepository {
       return mentoring.mentoringTags.any().tag.eq(tag);
     }
     return null;
+  }
+
+  private static class Searchable {
+
+    private NumberExpression<Double> score;
+
+    private static Searchable of(String keyword) {
+      Searchable searchable = new Searchable();
+      searchable.setScore(keyword);
+      return searchable;
+    }
+
+    private void setScore(String keyword) {
+      if (StringUtils.hasText(keyword)) {
+        NumberTemplate<Double> titleScore = getScore(mentoring.title, keyword);
+        NumberTemplate<Double> contentsScore = getScore(mentoring.mentoringDetail.contents, keyword);
+        score = titleScore.add(contentsScore);
+        return;
+      }
+      score = Expressions.asNumber(1.0);
+    }
+
+    private BooleanExpression getCondition() {
+      return score.gt(0);
+    }
+
+    private OrderSpecifier[] getSort() {
+      if (score.equals(Expressions.asNumber(1.0))) {
+        return new OrderSpecifier[]{mentoring.id.desc()};
+      }
+      return new OrderSpecifier[]{score.desc(), mentoring.id.desc()};
+    }
+
   }
 
 }

--- a/src/main/java/com/anchor/global/config/CacheConfig.java
+++ b/src/main/java/com/anchor/global/config/CacheConfig.java
@@ -1,0 +1,57 @@
+package com.anchor.global.config;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.Getter;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.caffeine.CaffeineCache;
+import org.springframework.cache.support.SimpleCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@EnableCaching
+@Configuration
+public class CacheConfig {
+
+  @Bean
+  public CacheManager cacheManager(List<CaffeineCache> caffeineCaches) {
+    SimpleCacheManager cacheManager = new SimpleCacheManager();
+    cacheManager.setCaches(caffeineCaches);
+    return cacheManager;
+  }
+
+  @Bean
+  public List<CaffeineCache> caffeineCaches() {
+    List<CaffeineCache> caches = Arrays.stream(CacheType.values())
+        .map(cache -> new CaffeineCache(
+            cache.getName(),
+            Caffeine.newBuilder()
+                .expireAfterWrite(cache.getExpireAfterWrite(), TimeUnit.SECONDS)
+                .maximumSize(cache.getMaximumSize())
+                .recordStats()
+                .build()
+        ))
+        .toList();
+    return caches;
+  }
+
+  @Getter
+  public enum CacheType {
+    TOP_MENTORING("topMentoring", 3_600, 100);
+
+    private final String name;
+    private final int expireAfterWrite;
+    private final int maximumSize;
+
+    CacheType(String name, int expireAfterWrite, int maximumSize) {
+      this.name = name;
+      this.expireAfterWrite = expireAfterWrite;
+      this.maximumSize = maximumSize;
+    }
+
+  }
+
+}

--- a/src/main/java/com/anchor/global/config/CustomFunctionContributor.java
+++ b/src/main/java/com/anchor/global/config/CustomFunctionContributor.java
@@ -1,0 +1,22 @@
+package com.anchor.global.config;
+
+import static org.hibernate.type.StandardBasicTypes.DOUBLE;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.boot.model.FunctionContributor;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomFunctionContributor implements FunctionContributor {
+
+  @Override
+  public void contributeFunctions(final FunctionContributions functionContributions) {
+    functionContributions.getFunctionRegistry()
+        .registerPattern("match_against", "match (?1) against (?2 in boolean mode)",
+            functionContributions.getTypeConfiguration()
+                .getBasicTypeRegistry()
+                .resolve(DOUBLE));
+  }
+
+}
+

--- a/src/main/java/com/anchor/global/config/DBInitConfig.java
+++ b/src/main/java/com/anchor/global/config/DBInitConfig.java
@@ -1,28 +1,22 @@
 package com.anchor.global.config;
 
 
-import javax.sql.DataSource;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.io.Resource;
-import org.springframework.jdbc.datasource.init.DataSourceInitializer;
-import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 
 @Configuration
 public class DBInitConfig {
 
-  @Value("classpath:init.sql")
-  private Resource dataScript;
-
-  @Bean
-  public DataSourceInitializer dataSourceInitializer(final DataSource dataSource) {
-    ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
-    populator.addScript(dataScript);
-    DataSourceInitializer initializer = new DataSourceInitializer();
-    initializer.setDataSource(dataSource);
-    initializer.setDatabasePopulator(populator);
-    return initializer;
-  }
+//  @Value("classpath:init.sql")
+//  private Resource dataScript;
+//
+//  @Bean
+//  public DataSourceInitializer dataSourceInitializer(final DataSource dataSource) {
+//    ResourceDatabasePopulator populator = new ResourceDatabasePopulator();
+//    populator.addScript(dataScript);
+//    DataSourceInitializer initializer = new DataSourceInitializer();
+//    initializer.setDataSource(dataSource);
+//    initializer.setDatabasePopulator(populator);
+//    return initializer;
+//  }
 
 }

--- a/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
+++ b/src/main/resources/META-INF/services/org.hibernate.boot.model.FunctionContributor
@@ -1,0 +1,1 @@
+com.anchor.global.config.CustomFunctionContributor

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,6 +13,9 @@ spring:
     username: ${MYSQL_USERNAME}
     password: ${MYSQL_PASSWORD}
 
+  cache:
+    type: caffeine
+
   jpa:
     hibernate:
       ddl-auto: none

--- a/src/main/resources/init.sql
+++ b/src/main/resources/init.sql
@@ -1,10 +1,15 @@
+start transaction;
+create fulltext index mentoring_title_idx on mentoring (title) with parser ngram;
+create fulltext index mentoring_contents_idx on mentoring_detail (contents) with parser ngram;
+commit;
+
 #### 회원정보 등록
 start transaction;
 insert into user (id, email, nickname, create_date, update_date, image)
 values (1, 'testMentor@test.com', '테스트멘토', now(), now(),
+        'https://anchor-image-stroage.s3.ap-northeast-2.amazonaws.com/%EA%B3%A0%EC%8A%B4%EB%8F%84%EC%B9%98_1704431943574.jpg'),
+       (2, 'testUser@test.com', '테스트유저', now(), now(),
         'https://anchor-image-stroage.s3.ap-northeast-2.amazonaws.com/%EA%B3%A0%EC%8A%B4%EB%8F%84%EC%B9%98_1704431943574.jpg');
-insert into user (id, email, nickname, create_date, update_date)
-values (2, 'testUser@test.com', '테스트유저', now(), now());
 commit;
 
 #### 멘토정보 등록
@@ -31,124 +36,27 @@ commit;
 
 #### 멘토링 상세내용 등록
 start transaction;
-insert into mentoring_detail (id, contents, create_date, update_date)
-values (1, '저는 IT 대기업이라 불리는 회사에서 총 10년 이상 재직하며 여러 팀에 소속되어 많은 프로젝트 개발에 참여 했고 최근 4년간은 스타트업 2개 회사에서 리더 포지션으로 업무를 진행한 경험을 가지고 있습니다.
 
-제 경험을 나누고 솔직한 이야기나 고민을 나눌 사람이 필요하다면 저를 찾아 주세요.
-
-● 멘토링 분야
-     -  Java 개발 Backend
-     -  개발자 커리어에 대한 고민, 이직에 대한 준비/고민
-     -  조직 운영, 매니징에 대한 경험 공유
-     -  프로젝트 진행, IT 직무 업무 진행에 대한 부분
-     -  모의 면접과 이력서 검토도 해드릴 수 있습니다.
-
-● 진행방식
-     -  Google Meet을 이용한 1:1(1:N가능) 화상회의 방식
-     -  예약이 되면 기재하신 연락처를 통해 접속주소를 알려드립니다.
-     -  상호 원활한 대화를 위해 " 이어폰과 마이크 혹은 헤드셋" 을 준비해 주세요!
-     -  마이크가 없을 경우 채팅창으로 대화를 나눠야하는데 시간 Loss가 발생할 수 있습니다.
-
-● 준 비 물
-     -  질문할 내용 list
-     -  솔직하게 이야기를 나눌 마음 :)
-     -  마이크+스피커 혹은 헤드셋 (상호 원활한 커뮤니케이션을 위해 필수)
-
-저와 이런 저런 이야기를 나눠보고 싶은 분들 누구나 환영합니다!
-정답은 아니겠지만 한 사람의 경험과 생각을 듣고 참고와 도움이 되시길 바라겠습니다.', now(), now());
-
-insert into mentoring_detail (id, contents, create_date, update_date)
-values (2, '👋🏼 자기소개
-저도 최근 취업 시장을 경험 했고, 비전공자였고, 부트캠프(국비)를 다녔으며, 나의 실력에 대해 아직도 부족하다고 생각합니다.
-
-취업 준비를 할 때, 많이 고민되고 개발자하려고 했던 것을 후회하기도 했습니다.
-
-혹시나 제가 했던 고민들을 똑같이 하고 계신 분들이 있을 것 같아서 이렇게 멘토링을 시작해보려합니다.
-
-🔎 가능한 멘토링 분야
-
-이력서 피드백, 모의 면접, 코드 리뷰 등을 해드릴 수 있으나 저도 실력이 많이 부족하기 때문에 이런 것보다는 현재 갖고 있는 고민에 대해서 상담하는 시간이 됐으면 좋겠습니다.
-🏃🏻‍♀️ 진행 방식
-
-Zoom 으로 1대1 진행할 예정입니다.
-30분이라 했지만, 추가 진행 가능 합니다. (추가 납입 x)
-📚 멘토링에 필요한 준비
-
-만약에 신청하실 분은 무한의 시간이 아니기에 미리 고민거리를 정리해서 오시면 더 알찬 시간이 될 것 같습니다.
-저의 도움이 여러분의 취준시간을 하루라도 줄이고, 조금이라도 더 좋을 곳에 합격할 수 있도록 도움이 되면 좋을 것 같습니다.', now(), now());
-
-
-insert into mentoring_detail (id, contents, create_date, update_date)
-values (3, 'ㅎㅇㅎㅇ 테스트용3', now(), now());
-
-insert into mentoring_detail (id, contents, create_date, update_date)
-values (4, 'ㅎㅇㅎㅇ 테스트용4', now(), now());
-
-insert into mentoring_detail (id, contents, create_date, update_date)
-values (5, 'ㅎㅇㅎㅇ 테스트용4', now(), now());
-
-insert into mentoring_detail (id, contents, create_date, update_date)
-values (6, 'ㅎㅇㅎㅇ 테스트용4', now(), now());
 commit;
 
 #### 멘토링정보 등록
 start transaction;
-insert into mentoring (id, title, duration_time, cost, create_date, update_date, mentor_id,
-                       mentoring_detail_id, total_application_number)
-values (1, '개발자 커리어, IT 업무, 커리어, 매니징, 백엔드개발, 이력서, 모의면접 등 멘토링', '1h30m', 10000, now(), now(), 1, 1, 20);
-insert into mentoring (id, title, duration_time, cost, create_date, update_date, mentor_id,
-                       mentoring_detail_id, total_application_number)
-values (2, '단테의 프론트엔드 / 개발자 커리어 / 취업, 이직 / 학습 멘토링', '1h30m', 10000, now(), now(), 1, 2, 18);
-
-insert into mentoring (id, title, duration_time, cost, create_date, update_date, mentor_id,
-                       mentoring_detail_id, total_application_number)
-values (3, '금융권 개발자 취업 / 물경력 이직 멘토링', '1h30m', 10000, now(), now(), 1, 3, 19);
-
-insert into mentoring (id, title, duration_time, cost, create_date, update_date, mentor_id,
-                       mentoring_detail_id, total_application_number)
-values (4, '실리콘밸리와 한국을 넘나드는 29년 개발자/리더/CTO', '1h30m', 10000, now(), now(), 1, 4, 25);
-
-insert into mentoring (id, title, duration_time, cost, create_date, update_date, mentor_id,
-                       mentoring_detail_id, total_application_number)
-values (5, 'SI에서 유명 스타트업까지 2년 만에 성장한 백엔드 엔지니어의 멘토링', '1h30m', 10000, now(), now(), 1, 5, 14);
-
-insert into mentoring (id, title, duration_time, cost, create_date, update_date, mentor_id,
-                       mentoring_detail_id, total_application_number)
-values (6, '대학교 생활 멘토링 / 대외활동 / AI 관련분야 / 대학원 진로 관련', '1h30m', 10000, now(), now(), 1, 6, 5);
 
 commit;
 
 #### 멘토링 태그 등록
 start transaction;
 insert into mentoring_tag (id, tag, create_date, update_date, mentoring_id)
-values (1, '백엔드', now(), now(), 1);
-
-insert into mentoring_tag (id, tag, create_date, update_date, mentoring_id)
-values (2, '자바', now(), now(), 1);
-
-insert into mentoring_tag (id, tag, create_date, update_date, mentoring_id)
-values (3, '프론트엔드', now(), now(), 2);
-
-insert into mentoring_tag (id, tag, create_date, update_date, mentoring_id)
-values (4, '리액트', now(), now(), 2);
-
-insert into mentoring_tag (id, tag, create_date, update_date, mentoring_id)
-values (5, 'DBA', now(), now(), 3);
-
-insert into mentoring_tag (id, tag, create_date, update_date, mentoring_id)
-values (6, '데브옵스', now(), now(), 3);
-
-insert into mentoring_tag (id, tag, create_date, update_date, mentoring_id)
-values (7, '자바', now(), now(), 4);
-
-insert into mentoring_tag (id, tag, create_date, update_date, mentoring_id)
-values (8, '백엔드', now(), now(), 4);
-
-insert into mentoring_tag (id, tag, create_date, update_date, mentoring_id)
-values (9, 'AI', now(), now(), 5);
-
-insert into mentoring_tag (id, tag, create_date, update_date, mentoring_id)
-values (10, '파이썬', now(), now(), 5);
+values (1, '백엔드', now(), now(), 1),
+       (2, '자바', now(), now(), 1),
+       (3, '프론트엔드', now(), now(), 2),
+       (4, '리액트', now(), now(), 2),
+       (5, 'DBA', now(), now(), 3),
+       (6, '데브옵스', now(), now(), 3),
+       (7, '자바', now(), now(), 4),
+       (8, '백엔드', now(), now(), 4),
+       (9, 'AI', now(), now(), 5),
+       (10, '파이썬', now(), now(), 5);
 commit;
 
 #### 멘토링 결제내역 등록

--- a/src/test/java/com/anchor/AnchorApplicationTests.java
+++ b/src/test/java/com/anchor/AnchorApplicationTests.java
@@ -1,10 +1,5 @@
 package com.anchor;
 
-import com.anchor.domain.mentor.domain.Career;
-import com.anchor.domain.mentor.domain.Mentor;
-import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest

--- a/src/test/java/com/anchor/AnchorApplicationTests.java
+++ b/src/test/java/com/anchor/AnchorApplicationTests.java
@@ -1,9 +1,93 @@
 package com.anchor;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.anchor.domain.mentor.domain.Career;
+import com.anchor.domain.mentor.domain.Mentor;
+import com.anchor.domain.mentoring.api.service.MentoringService;
+import com.anchor.domain.mentoring.api.service.response.MentoringSearchResult;
+import com.anchor.domain.mentoring.api.service.response.TopMentoring;
+import com.anchor.domain.mentoring.domain.Mentoring;
+import com.anchor.domain.mentoring.domain.repository.MentoringRepository;
+import com.anchor.domain.user.domain.User;
+import com.anchor.domain.user.domain.UserRole;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.benmanes.caffeine.cache.Cache;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.cache.CacheManager;
 
 @SpringBootTest
 class AnchorApplicationTests {
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @Autowired
+  CacheManager cacheManager;
+
+  @MockBean
+  private MentoringRepository mentoringRepository;
+
+  @Autowired
+  private MentoringService mentoringService;
+
+  @Test
+  @DisplayName("신청자 수를 기준으로 상위 10개의 멘토링을 캐싱해 가져옵니다.")
+  void test() throws JsonProcessingException {
+    // given
+    User user = User.builder()
+        .email("email")
+        .image("image")
+        .role(UserRole.MENTOR)
+        .nickname("nickname")
+        .build();
+    Mentor mentor = Mentor.builder()
+        .companyEmail("companyEmail")
+        .career(Career.LEADER)
+        .accountNumber("1234")
+        .accountName("accountName")
+        .bankName("bankName")
+        .user(user)
+        .build();
+    Mentoring mentoring = Mentoring.builder()
+        .title("title")
+        .mentor(mentor)
+        .durationTime("1h30m")
+        .cost(10000)
+        .mentoringDetail(null)
+        .build();
+
+    List<MentoringSearchResult> topMentorings = IntStream.range(0, 10)
+        .mapToObj(i -> MentoringSearchResult.of(mentoring))
+        .toList();
+
+    given(mentoringRepository.findTopMentorings()).willReturn(topMentorings);
+    String topMentoring = objectMapper.writeValueAsString(new TopMentoring(topMentorings));
+
+    // when
+    IntStream.range(0, 10)
+        .forEach(i -> mentoringService.getTopMentorings());
+    Cache cache = (Cache) Objects.requireNonNull(cacheManager.getCache("topMentoring"))
+        .getNativeCache();
+    String cachedTopMentorings = objectMapper.writeValueAsString(cache.asMap()
+        .get("topMentoring"));
+
+    // then
+    verify(mentoringRepository, times(1)).findTopMentorings();
+    assertThat(topMentoring)
+        .isEqualTo(cachedTopMentorings);
+  }
 
 }
 

--- a/src/test/java/com/anchor/domain/mentoring/api/controller/MentoringCacheTest.java
+++ b/src/test/java/com/anchor/domain/mentoring/api/controller/MentoringCacheTest.java
@@ -1,0 +1,44 @@
+package com.anchor.domain.mentoring.api.controller;
+
+import com.anchor.domain.mentoring.api.service.MentoringService;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+public class MentoringCacheTest {
+
+  private static Logger logger = LoggerFactory.getLogger(MentoringCacheTest.class);
+  @Autowired
+  private MentoringService mentoringService;
+
+  @Test
+  @DisplayName("캐싱 이전과 이후의 속도를 비교합니다.")
+  void test() {
+    long start = System.currentTimeMillis();
+    mentoringService.getTopMentorings();
+    long end = System.currentTimeMillis();
+    long notCached = end - start;
+
+    start = System.currentTimeMillis();
+    mentoringService.getTopMentorings();
+    end = System.currentTimeMillis();
+    long cached = end - start;
+
+    logger.info("캐싱 처리 전 : {}ms", notCached);
+    logger.info("캐싱 처리 후 : {}ms", cached);
+
+    Assertions.assertThat(notCached)
+        .isGreaterThan(cached);
+  }
+
+}

--- a/src/test/java/com/anchor/domain/mentoring/api/controller/MentoringControllerTest.java
+++ b/src/test/java/com/anchor/domain/mentoring/api/controller/MentoringControllerTest.java
@@ -29,7 +29,6 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
-import org.springframework.web.client.RestClient;
 
 @MockBean(JpaMetamodelMappingContext.class)
 @WithMockUser(username = "hossi", roles = {"MENTOR"})
@@ -125,7 +124,6 @@ class MentoringControllerTest {
     // given
     MockHttpSession session = new MockHttpSession();
     session.setAttribute("user", new SessionUser());
-    RestClient restClient = RestClient.create();
     byte[] image = new byte[0];
 
     MockMultipartFile file = new MockMultipartFile("image", "image.png", MediaType.IMAGE_PNG_VALUE,


### PR DESCRIPTION
# Abtract
- 멘토링 목록 검색 쿼리문에 fulltext index 적용
- 인기멘토링 캐싱 적용

# Detail of Changes
## 1. 멘토링 목록 검색 쿼리문
- Mysql InnoDB fulltext index를 도입해 검색 결과에 대한 정밀도를 향상시켰습니다.

### 1차 정렬 기준
- 기준 1. 입력받은 키워드와 멘토링 제목 및 내용이 일치하는 정도를 기준으로 내림차순
- 기준 2. 아이디를 기준으로 내림차순 (= 최신 멘토링 등록순)

### 2차 정렬 기준
- 기준 1. 멘토링 신청자 수를 기준으로 내림차순
- 참고로 2차 정렬 기준은 요청 파라미터에 따라 달라질 수 있습니다.

## 2. 인기멘토링 캐싱 적용
저희는 홈페이지에 신청자 수를 기준으로 인기 있는 멘토링 10개를 Caffeine 로컬 캐시를 통해 서빙합니다.

### 규칙
- Caffeine Cache (로컬 캐시)를 사용합니다.
- 60분마다 캐시를 초기화하고 새로운 데이터를 갱신합니다.

### 적용 이유
- 홈페이지 Hit 율이 매우 높기 때문에 캐싱을 적용하면 성능을 개선하고, 동시에 DB 커넥션과 같은 자원을 아낄 수 있다고 판단했습니다.
- 동시에 동기화 및 실시간성보다 히트율이 크게 중요한 부분이라고 생각이 되었습니다. 
- 따라서 분산 캐시가 아니라 로컬 캐시를 사용했고, 동시에 60분이라는 시간을 정했습니다.

### Caffeine Cache인 이유
- Caffeine Cache가 EhCache에 비해 설정에 대한 폭은 적지만, 성능상 벤치마킹 점수가 우수합니다.
- 현 상황에서는 복잡한 설정이 필요한게 아니라 Caffeine Cache가 적합하다고 판단했습니다.
- [Caffeine Cache Banchmark](https://github.com/ben-manes/caffeine/wiki/Benchmarks)

### 결과
- 다음과 같은 성능 향상을 이룰 수 있었습니다.

![image](https://github.com/Team-RecruTe/Anchor-Service/assets/58262954/2807112a-0920-45dd-bae4-b1c3ac48af66)