### PR TITLE
chore: 예외 구조 설계 및 구현

### DIFF
--- a/src/main/java/com/anchor/global/exception/ServiceException.java
+++ b/src/main/java/com/anchor/global/exception/ServiceException.java
@@ -1,0 +1,13 @@
+package com.anchor.global.exception;
+
+import com.anchor.global.exception.error.ServiceErrorCode;
+import com.anchor.global.exception.response.ErrorDetail;
+import lombok.Getter;
+
+@Getter
+public abstract class ServiceException extends RuntimeException {
+
+  private ServiceErrorCode errorCode;
+  private ErrorDetail details;
+
+}

--- a/src/main/java/com/anchor/global/exception/error/ServiceErrorCode.java
+++ b/src/main/java/com/anchor/global/exception/error/ServiceErrorCode.java
@@ -1,0 +1,16 @@
+package com.anchor.global.exception.error;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ServiceErrorCode {
+
+  CUSTOM_ERROR_CODE(HttpStatus.BAD_REQUEST, "커스텀 에러 코드");
+
+  private final HttpStatus status;
+  private final String message;
+
+}

--- a/src/main/java/com/anchor/global/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/anchor/global/exception/handler/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.anchor.global.exception.handler;
+
+import com.anchor.global.exception.ServiceException;
+import com.anchor.global.exception.response.ServiceErrorResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(ServiceException.class)
+  public ResponseEntity<ServiceErrorResponse> handleServiceException(ServiceException ex) {
+    ServiceErrorResponse response = new ServiceErrorResponse(ex);
+    return ResponseEntity.status(response.getStatus())
+        .body(response);
+  }
+
+}

--- a/src/main/java/com/anchor/global/exception/response/ErrorDetail.java
+++ b/src/main/java/com/anchor/global/exception/response/ErrorDetail.java
@@ -1,0 +1,10 @@
+package com.anchor.global.exception.response;
+
+import lombok.Getter;
+
+@Getter
+public abstract class ErrorDetail {
+
+  private String message;
+
+}

--- a/src/main/java/com/anchor/global/exception/response/ErrorDetail.java
+++ b/src/main/java/com/anchor/global/exception/response/ErrorDetail.java
@@ -1,10 +1,12 @@
 package com.anchor.global.exception.response;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
+@RequiredArgsConstructor
 public abstract class ErrorDetail {
 
-  private String message;
+  private final String message;
 
 }

--- a/src/main/java/com/anchor/global/exception/response/ServiceErrorResponse.java
+++ b/src/main/java/com/anchor/global/exception/response/ServiceErrorResponse.java
@@ -1,0 +1,36 @@
+package com.anchor.global.exception.response;
+
+import com.anchor.global.exception.ServiceException;
+import com.anchor.global.exception.error.ServiceErrorCode;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public class ServiceErrorResponse {
+
+  @JsonIgnore
+  private final HttpStatus status;
+  private final ErrorCode error;
+  private final ErrorDetail details;
+
+  public ServiceErrorResponse(ServiceException ex) {
+    ServiceErrorCode errorCode = ex.getErrorCode();
+    this.status = errorCode.getStatus();
+    this.error = new ErrorCode(
+        errorCode.name(),
+        ex.getMessage()
+    );
+    this.details = ex.getDetails();
+  }
+
+  @RequiredArgsConstructor
+  public static class ErrorCode {
+
+    private final String code;
+    private final String message;
+
+  }
+
+}

--- a/src/main/java/com/anchor/global/exception/response/SimpleErrorDetail.java
+++ b/src/main/java/com/anchor/global/exception/response/SimpleErrorDetail.java
@@ -1,0 +1,9 @@
+package com.anchor.global.exception.response;
+
+public class SimpleErrorDetail extends ErrorDetail {
+
+  public SimpleErrorDetail(String message) {
+    super(message);
+  }
+
+}


### PR DESCRIPTION
# Abtract
- 예외 구조 설계 및 구현

# Detail of Changes
## 예외 구조
- `GlobalExceptionHandler`: 특별한 경우를 제외하고 모든 서비스에 대한 예외를 처리하는 Handler 클래스입니다.
- `ServiceErrorCode`: 비즈니스 로직상 발생할 수 있는 에러를 정의하는 Enum 클래스입니다.
- `ServiceErrorResponse`: 예외에 대한 응답 데이터를 담는 클래스입니다.
- `ServiceException`: Service 내에서 발생할 수 있는 모든 예외의 부모 클래스입니다. 이를 상속받아 서비스에 따른 예외 클래스를 생성할 수 있습니다.
- `ErrorDetail`: 에러에 대한 상세내용을 담는 모든 클래스의 부모 클래스입니다. SimpleErrorDetail을 사용하거나 필요에 따라 상속받아 새로운 클래스를 생성할 수 있습니다.

# To Others